### PR TITLE
Allow rke_logreader_to to read rancher and systemd logs

### DIFF
--- a/policy/centos7/rancher-selinux.spec
+++ b/policy/centos7/rancher-selinux.spec
@@ -3,6 +3,10 @@
 %define selinux_policyver 3.13.1-252
 %define container_policyver 2.107.3
 
+%define relabel_files() \
+mkdir -p /var/lib/rancher/rke; \
+restorecon -R /var/lib/rancher
+
 Name:   rancher-selinux
 Version:	%{rancher_selinux_version}
 Release:	%{rancher_selinux_release}.el7
@@ -31,6 +35,7 @@ install -m 644 %{SOURCE0} %{buildroot}%{_datadir}/selinux/packages
 semodule -n -i %{_datadir}/selinux/packages/rancher.pp
 if /usr/sbin/selinuxenabled ; then
     /usr/sbin/load_policy
+    %relabel_files
 fi;
 exit 0
 

--- a/policy/centos7/rancher.fc
+++ b/policy/centos7/rancher.fc
@@ -1,0 +1,1 @@
+/var/lib/rancher/rke(/.*)?                                              gen_context(system_u:object_r:container_var_lib_t,s0)

--- a/policy/centos7/rancher.te
+++ b/policy/centos7/rancher.te
@@ -22,3 +22,4 @@ allow rke_logreader_t container_log_t:lnk_file { getattr read };
 allow rke_logreader_t container_log_t:file { getattr open read };
 allow rke_logreader_t container_var_lib_t:dir search;
 allow rke_logreader_t container_var_lib_t:file { getattr open read };
+allow rke_logreader_t container_var_lib_t:lnk_file { getattr read };

--- a/policy/centos7/rancher.te
+++ b/policy/centos7/rancher.te
@@ -10,6 +10,7 @@ gen_require(`
 gen_require(`
         type container_runtime_t, unconfined_service_t;
         type container_log_t;
+        type syslogd_var_run_t;
         class dir { read search };
         class file { open read };
         class lnk_file { getattr read };
@@ -23,3 +24,5 @@ allow rke_logreader_t container_log_t:file { getattr open read };
 allow rke_logreader_t container_var_lib_t:dir search;
 allow rke_logreader_t container_var_lib_t:file { getattr open read };
 allow rke_logreader_t container_var_lib_t:lnk_file { getattr read };
+allow rke_logreader_t syslogd_var_run_t:dir read;
+allow rke_logreader_t syslogd_var_run_t:file { getattr open read };

--- a/policy/centos8/rancher-selinux.spec
+++ b/policy/centos8/rancher-selinux.spec
@@ -3,6 +3,10 @@
 %define selinux_policyver 3.13.1-252
 %define container_policyver 2.144.0-1
 
+%define relabel_files() \
+mkdir -p /var/lib/rancher/rke; \
+restorecon -R /var/lib/rancher
+
 Name:   rancher-selinux
 Version:	%{rancher_selinux_version}
 Release:	%{rancher_selinux_release}.el8
@@ -31,6 +35,7 @@ install -m 644 %{SOURCE0} %{buildroot}%{_datadir}/selinux/packages
 semodule -n -i %{_datadir}/selinux/packages/rancher.pp
 if /usr/sbin/selinuxenabled ; then
     /usr/sbin/load_policy
+    %relabel_files
 fi;
 exit 0
 

--- a/policy/centos8/rancher.fc
+++ b/policy/centos8/rancher.fc
@@ -1,0 +1,1 @@
+/var/lib/rancher/rke(/.*)?                                              gen_context(system_u:object_r:container_var_lib_t,s0)

--- a/policy/centos8/rancher.te
+++ b/policy/centos8/rancher.te
@@ -22,3 +22,4 @@ allow rke_logreader_t container_log_t:lnk_file { getattr read };
 allow rke_logreader_t container_log_t:file { getattr open read };
 allow rke_logreader_t container_var_lib_t:dir search;
 allow rke_logreader_t container_var_lib_t:file { getattr open read };
+allow rke_logreader_t container_var_lib_t:lnk_file { getattr read };

--- a/policy/centos8/rancher.te
+++ b/policy/centos8/rancher.te
@@ -10,6 +10,7 @@ gen_require(`
 gen_require(`
         type container_runtime_t, unconfined_service_t;
         type container_log_t;
+        type syslogd_var_run_t;
         class dir { read search };
         class file { open read };
         class lnk_file { getattr read };
@@ -23,3 +24,5 @@ allow rke_logreader_t container_log_t:file { getattr open read };
 allow rke_logreader_t container_var_lib_t:dir search;
 allow rke_logreader_t container_var_lib_t:file { getattr open read };
 allow rke_logreader_t container_var_lib_t:lnk_file { getattr read };
+allow rke_logreader_t syslogd_var_run_t:dir read;
+allow rke_logreader_t syslogd_var_run_t:file { getattr open read };


### PR DESCRIPTION
#1

Allow rke_logreader_t to read systemd logs

Without this patch, the logging aggregator for RKE2 cannot collect
systemd logs for the RKE2 service. This change expands the permissions
of the rke_logreader_t type to allow reading the journal files produced
by systemd.

#2

Allow rke_logreader_t to read rancher logs

Without this patch, logging aggregator pods for RKE1 cannot read
symlinks under /var/lib/rancher/rke even though their rke_logreader_t
label allows them to read container logs and docker logs. Add a policy
and fcontext equivalent to the existing RKE2 log policy to allow
containers with the rke_logreader_t label to read linked logs under
/var/lib/rancher/rke/.

rancher/rancher#30949
Needed by rancher/charts#1049