### PR TITLE
Add 'map' permission for centos8 rancher policy

### DIFF
--- a/policy/centos8/rancher.te
+++ b/policy/centos8/rancher.te
@@ -25,4 +25,4 @@ allow rke_logreader_t container_var_lib_t:dir search;
 allow rke_logreader_t container_var_lib_t:file { getattr open read };
 allow rke_logreader_t container_var_lib_t:lnk_file { getattr read };
 allow rke_logreader_t syslogd_var_run_t:dir read;
-allow rke_logreader_t syslogd_var_run_t:file { getattr open read };
+allow rke_logreader_t syslogd_var_run_t:file { getattr map open read };


### PR DESCRIPTION
Without this patch, on CentOS 8 only, the rancher-logging rke2
aggregator tries and fails to use the 'map' call on the journald logs.
This change adds this permission to the CentOS 8 policy. This call is
not made on CentOS 7 so the policy change is not made for CentOS 7.

https://github.com/rancher/rancher/issues/31309