### PR TITLE
Add 'map' for container logs for CentOS 8

### DIFF
--- a/policy/centos8/rancher.te
+++ b/policy/centos8/rancher.te
@@ -20,7 +20,7 @@ virt_sandbox_domain(rke_logreader_t)
 corenet_unconfined(rke_logreader_t)
 allow rke_logreader_t container_log_t:dir { open read search };
 allow rke_logreader_t container_log_t:lnk_file { getattr read };
-allow rke_logreader_t container_log_t:file { getattr open read };
+allow rke_logreader_t container_log_t:file { getattr map open read };
 allow rke_logreader_t container_var_lib_t:dir search;
 allow rke_logreader_t container_var_lib_t:file { getattr open read };
 allow rke_logreader_t container_var_lib_t:lnk_file { getattr read };


### PR DESCRIPTION
By default, if the `systemdLogPath` variable is unchanged from the
default of /var/log/journal in the `rancher-logging` chart, the Fluentd
container will create the /var/log/journal directory[1]. Once it is
created, systemd will treat the Storage method as "persistent" even if
the Storage setting is unchanged[2]. Since /var/log is mounted by the
Pod, then on an SELinux-enabled/enforcing system, the /var/log/journal
directory will get relabeled to container_log_t. On CentOS 8, the
rke_logreader_t domain needs the 'map' permission to read these files.
This does not seem to be a requirement for CentOS 7, so this change only
updates the policy for CentOS 8.

[1] https://github.com/rancher/fluentd/blob/0c484d7beeb67f7efbdfc87727989b5061b89140/package/run.sh
[2] https://www.freedesktop.org/software/systemd/man/journald.conf.html#Storage=