### PR TITLE
Allow logreader to read var_log_t

### DIFF
--- a/policy/centos7/rancher.te
+++ b/policy/centos7/rancher.te
@@ -11,6 +11,7 @@ gen_require(`
         type container_runtime_t, unconfined_service_t;
         type container_log_t;
         type syslogd_var_run_t;
+        type var_log_t;
         class dir { read search };
         class file { open read };
         class lnk_file { getattr read };
@@ -26,3 +27,5 @@ allow rke_logreader_t container_var_lib_t:file { getattr open read };
 allow rke_logreader_t container_var_lib_t:lnk_file { getattr read };
 allow rke_logreader_t syslogd_var_run_t:dir read;
 allow rke_logreader_t syslogd_var_run_t:file { getattr open read };
+allow rke_logreader_t var_log_t:dir read;
+allow rke_logreader_t var_log_t:file { getattr open read };

--- a/policy/centos8/rancher.te
+++ b/policy/centos8/rancher.te
@@ -11,6 +11,7 @@ gen_require(`
         type container_runtime_t, unconfined_service_t;
         type container_log_t;
         type syslogd_var_run_t;
+        type var_log_t;
         class dir { read search };
         class file { open read };
         class lnk_file { getattr read };
@@ -26,3 +27,5 @@ allow rke_logreader_t container_var_lib_t:file { getattr open read };
 allow rke_logreader_t container_var_lib_t:lnk_file { getattr read };
 allow rke_logreader_t syslogd_var_run_t:dir read;
 allow rke_logreader_t syslogd_var_run_t:file { getattr map open read };
+allow rke_logreader_t var_log_t:dir read;
+allow rke_logreader_t var_log_t:file { getattr map open read };


### PR DESCRIPTION
It's not the default on CentOS, but if persistent storage is enabled for
journald by setting Storage=persistent in /etc/systemd/journald.conf,
the log files will have the same label as the rest of /var/log, which is
var_log_t. This kind of journald configuration is valid and supported by
the logging chart, so add policy rules for both CentOS 7 and CentOS 8 to
allow the rke_logreader_t domain to read this files.

Related to https://github.com/rancher/rancher/issues/31309