### PR TITLE
Add rke_kubereader_t to read kubernetes_file_t

### DIFF
--- a/Dockerfile.centos8.dapper
+++ b/Dockerfile.centos8.dapper
@@ -1,5 +1,9 @@
 FROM centos:8
 
+# CentOS 8 has reached EOL: https://www.centos.org/centos-linux-eol/
+# Therefore, we need to switch the mirrorlist for the appstream repo to point to http://vault.centos.org
+RUN pushd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && popd
+
 RUN yum install -y epel-release && yum -y install container-selinux selinux-policy-devel yum-utils rpm-build git jq
 
 ENV DAPPER_SOURCE /source

--- a/policy/centos7/rancher.te
+++ b/policy/centos7/rancher.te
@@ -5,6 +5,23 @@ gen_require(`
 ')
 
 ########################
+# type rke_kubereader_t #
+########################
+gen_require(`
+        type container_runtime_t, unconfined_service_t;
+        type kubernetes_file_t;
+        class dir { open read search };
+        class file { getaddr open read };
+        class lnk_file { getattr read };
+')
+container_domain_template(rke_kubereader)
+virt_sandbox_domain(rke_kubereader_t)
+corenet_unconfined(rke_kubereader_t)
+allow rke_kubereader_t kubernetes_file_t:dir { open read search };
+allow rke_kubereader_t kubernetes_file_t:file { getattr open read };
+allow rke_kubereader_t kubernetes_file_t:lnk_file { getattr read };
+
+########################
 # type rke_logreader_t #
 ########################
 gen_require(`

--- a/policy/centos8/rancher.te
+++ b/policy/centos8/rancher.te
@@ -5,6 +5,23 @@ gen_require(`
 ')
 
 ########################
+# type rke_kubereader_t #
+########################
+gen_require(`
+        type container_runtime_t, unconfined_service_t;
+        type kubernetes_file_t;
+        class dir { open read search };
+        class file { getaddr open read };
+        class lnk_file { getattr read };
+')
+container_domain_template(rke_kubereader)
+virt_sandbox_domain(rke_kubereader_t)
+corenet_unconfined(rke_kubereader_t)
+allow rke_kubereader_t kubernetes_file_t:dir { open read search };
+allow rke_kubereader_t kubernetes_file_t:file { getattr open read };
+allow rke_kubereader_t kubernetes_file_t:lnk_file { getattr read };
+
+########################
 # type rke_logreader_t #
 ########################
 gen_require(`


### PR DESCRIPTION
`rancher-pushprox` (a subchart of Rancher Monitoring V2) requires the ability to get certs from `/etc/kubernetes/ssl`.

Therefore, this role adds permissions to access all files typed as `kubernetes_file_t`, as defined in https://github.com/containers/container-selinux/blob/7ffded0091bc146cc47808fa101246091c66b9d8/container.fc#L114.

Related Issue: https://github.com/rancher/rancher/issues/36105