### PR TITLE
Dockerfile.centos8.dapper: use AlmaLinux8 instead of CentOS8

### DIFF
--- a/Dockerfile.centos8.dapper
+++ b/Dockerfile.centos8.dapper
@@ -1,8 +1,4 @@
-FROM centos:8
-
-# CentOS 8 has reached EOL: https://www.centos.org/centos-linux-eol/
-# Therefore, we need to switch the mirrorlist for the appstream repo to point to http://vault.centos.org
-RUN pushd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && popd
+FROM almalinux:8
 
 RUN yum install -y epel-release && yum -y install container-selinux selinux-policy-devel yum-utils rpm-build git jq
 


### PR DESCRIPTION
As there is no updated CentOS8 image that is built on CentOS Stream and the repositories for non-stream have been archived, it would need workarounds to get CentOS8 to run properly.

See https://github.com/rancher/rancher-selinux/pull/10/commits/fb35171078397b7dc5e67cf02a0ee4a99d51c31e and https://github.com/rancher/rancher-selinux/pull/10/commits/8fe92aa1f0c856fda78451260ac8ba1c35daaef2 for example.

Rather than hacking workarounds, use the AlmaLinux8 image which promises to be bit-compatible with RHEL8.