### PR TITLE
Add Fedora / CoreOS 37

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -372,3 +372,99 @@ steps:
     - refs/tags/*
     event:
     - tag
+
+---
+kind: pipeline
+name: RPM Build Fedora37
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: Build RPM Fedora37
+  image: fedora:37
+  commands:
+  - policy/fedora37/scripts/build
+
+- name: Sign RPM Fedora37 (dry-run)
+  image: fedora:37
+  commands:
+  - policy/fedora37/scripts/sign --dry-run
+  when:
+    event:
+    - pull_request
+
+- name: Sign RPM Fedora37
+  image: fedora:37
+  environment:
+    PRIVATE_KEY:
+      from_secret: private_key
+    PRIVATE_KEY_PASS_PHRASE:
+      from_secret: private_key_pass_phrase
+    TESTING_PRIVATE_KEY:
+      from_secret: testing_private_key
+    TESTING_PRIVATE_KEY_PASS_PHRASE:
+      from_secret: testing_private_key_pass_phrase
+  commands:
+  - policy/fedora37/scripts/sign
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag
+
+- name: Create repo metadata for Fedora37
+  image: fedora:37
+  commands:
+  - policy/fedora37/scripts/repo-metadata
+
+- name: Yum Repo Upload Fedora37
+  image: fedora:37
+  environment:
+    AWS_S3_BUCKET:
+      from_secret: aws_s3_bucket
+    AWS_ACCESS_KEY_ID:
+      from_secret: aws_access_key_id
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: aws_secret_access_key
+    TESTING_AWS_S3_BUCKET:
+      from_secret: testing_aws_s3_bucket
+    TESTING_AWS_ACCESS_KEY_ID:
+      from_secret: testing_aws_access_key_id
+    TESTING_AWS_SECRET_ACCESS_KEY:
+      from_secret: testing_aws_secret_access_key
+  commands:
+  - policy/fedora37/scripts/upload-repo
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag
+
+- name: GitHub Release Fedora37
+  image: plugins/github-release
+  settings:
+    api_key:
+      from_secret: github_token
+    prerelease: true
+    checksum:
+    - sha256
+    checksum_file: CHECKSUMsum-fedora37-noarch.txt
+    checksum_flatten: true
+    files:
+    - "policy/fedora37/dist/**/*.rpm"
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ CENTOS7_TARGETS := $(addprefix centos7-,$(shell ls policy/centos7/scripts))
 CENTOS8_TARGETS := $(addprefix centos8-,$(shell ls policy/centos8/scripts))
 CENTOS9_TARGETS := $(addprefix centos9-,$(shell ls policy/centos9/scripts))
 MICROOS_TARGETS := $(addprefix microos-,$(shell ls policy/microos/scripts))
+FEDORA37_TARGETS := $(addprefix fedora37-,$(shell ls policy/fedora37/scripts))
 
 .dapper:
 	@echo Downloading dapper
@@ -22,4 +23,7 @@ $(CENTOS9_TARGETS): .dapper
 $(MICROOS_TARGETS): .dapper
 	./.dapper -f Dockerfile.microos.dapper $(@:microos-%=%)
 
-.PHONY: $(CENTOS7_TARGETS) $(CENTOS8_TARGETS) $(CENTOS9_TARGETS) $(MICROOS_TARGETS)
+$(FEDORA37_TARGETS): .dapper
+	./.dapper -f Dockerfile.fedora37.dapper $(@:fedora37-%=%)
+
+.PHONY: $(CENTOS7_TARGETS) $(CENTOS8_TARGETS) $(CENTOS9_TARGETS) $(MICROOS_TARGETS) $(FEDORA37_TARGETS)

--- a/policy/fedora37/rancher-selinux.spec
+++ b/policy/fedora37/rancher-selinux.spec
@@ -1,0 +1,56 @@
+# vim: sw=4:ts=4:et
+
+%define selinux_policyver 37.19-1
+%define container_policyver 2.204.0-1
+
+%define relabel_files() \
+mkdir -p /var/lib/rancher/rke /etc/kubernetes /opt/rke; \
+restorecon -R /var/lib/rancher /etc/kubernetes /opt/rke;
+
+Name:   rancher-selinux
+Version:	%{rancher_selinux_version}
+Release:	%{rancher_selinux_release}.fc37
+Summary:	SELinux policy module for Rancher
+
+Group:	System Environment/Base
+License:	ASL 2.0
+URL:		http://rancher.com
+Source0:	rancher.pp
+
+BuildRequires: container-selinux >= %{container_policyver}
+
+Requires: policycoreutils, libselinux-utils
+Requires(post): selinux-policy >= %{selinux_policyver}, policycoreutils, container-selinux >= %{container_policyver}
+Requires(postun): policycoreutils
+
+BuildArch: noarch
+
+%description
+This package installs and sets up the SELinux policy security module for Rancher.
+
+%install
+install -d %{buildroot}%{_datadir}/selinux/packages
+install -m 644 %{SOURCE0} %{buildroot}%{_datadir}/selinux/packages
+
+
+%post
+semodule -n -i %{_datadir}/selinux/packages/rancher.pp
+if /usr/sbin/selinuxenabled ; then
+    /usr/sbin/load_policy
+    %relabel_files
+fi;
+exit 0
+
+%postun
+if [ $1 -eq 0 ]; then
+    semodule -n -r rancher
+    if /usr/sbin/selinuxenabled ; then
+       /usr/sbin/load_policy
+    fi;
+fi;
+exit 0
+
+%files
+%attr(0600,root,root) %{_datadir}/selinux/packages/rancher.pp
+
+%changelog

--- a/policy/fedora37/rancher.fc
+++ b/policy/fedora37/rancher.fc
@@ -1,0 +1,2 @@
+/var/lib/rancher/rke(/.*)?                                              gen_context(system_u:object_r:container_var_lib_t,s0)
+/opt/rke(/.*)?                                                          gen_context(system_u:object_r:rke_opt_t,s0)

--- a/policy/fedora37/rancher.te
+++ b/policy/fedora37/rancher.te
@@ -44,9 +44,9 @@ allow rke_logreader_t container_var_lib_t:dir search;
 allow rke_logreader_t container_var_lib_t:file { getattr open read };
 allow rke_logreader_t container_var_lib_t:lnk_file { getattr read };
 allow rke_logreader_t syslogd_var_run_t:dir read;
-allow rke_logreader_t syslogd_var_run_t:file { getattr open read };
+allow rke_logreader_t syslogd_var_run_t:file { getattr map open read };
 allow rke_logreader_t var_log_t:dir read;
-allow rke_logreader_t var_log_t:file { getattr open read };
+allow rke_logreader_t var_log_t:file { getattr map open read };
 
 ########################
 # type rke_container_t #

--- a/policy/fedora37/rancher.te
+++ b/policy/fedora37/rancher.te
@@ -1,0 +1,105 @@
+policy_module(rancher, 1.0.0)
+
+gen_require(`
+    type container_runtime_t, unconfined_service_t;
+    type container_file_t;
+')
+
+########################
+# type rke_kubereader_t #
+########################
+gen_require(`
+        type container_runtime_t, unconfined_service_t;
+        type kubernetes_file_t;
+        class dir { open read search };
+        class file { getaddr open read };
+        class lnk_file { getattr read };
+')
+container_domain_template(rke_kubereader, container)
+virt_sandbox_domain(rke_kubereader_t)
+corenet_unconfined(rke_kubereader_t)
+allow rke_kubereader_t kubernetes_file_t:dir { open read search };
+allow rke_kubereader_t kubernetes_file_t:file { getattr open read };
+allow rke_kubereader_t kubernetes_file_t:lnk_file { getattr read };
+
+########################
+# type rke_logreader_t #
+########################
+gen_require(`
+        type container_runtime_t, unconfined_service_t;
+        type container_log_t;
+        type syslogd_var_run_t;
+        type var_log_t;
+        class dir { read search };
+        class file { open read };
+        class lnk_file { getattr read };
+')
+container_domain_template(rke_logreader, container)
+virt_sandbox_domain(rke_logreader_t)
+corenet_unconfined(rke_logreader_t)
+allow rke_logreader_t container_log_t:dir { open read search };
+allow rke_logreader_t container_log_t:lnk_file { getattr read };
+allow rke_logreader_t container_log_t:file { getattr open read };
+allow rke_logreader_t container_var_lib_t:dir search;
+allow rke_logreader_t container_var_lib_t:file { getattr open read };
+allow rke_logreader_t container_var_lib_t:lnk_file { getattr read };
+allow rke_logreader_t syslogd_var_run_t:dir read;
+allow rke_logreader_t syslogd_var_run_t:file { getattr open read };
+allow rke_logreader_t var_log_t:dir read;
+allow rke_logreader_t var_log_t:file { getattr open read };
+
+########################
+# type rke_container_t #
+########################
+gen_require(`
+        type container_runtime_t, unconfined_service_t;
+        type container_log_t;
+        type kubernetes_file_t;
+        type container_var_run_t;
+        class dir { read search };
+        class file { open read };
+')
+type rke_opt_t;
+files_type(rke_opt_t)
+container_domain_template(rke_container, container)
+virt_sandbox_domain(rke_container_t)
+corenet_unconfined(rke_container_t)
+manage_dirs_pattern(rke_container_t, container_var_lib_t, container_var_lib_t)
+manage_files_pattern(rke_container_t, container_var_lib_t, container_var_lib_t)
+manage_dirs_pattern(rke_container_t, container_log_t, container_log_t)
+manage_files_pattern(rke_container_t, container_log_t, container_log_t)
+manage_dirs_pattern(rke_container_t, kubernetes_file_t, kubernetes_file_t)
+manage_files_pattern(rke_container_t, kubernetes_file_t, kubernetes_file_t)
+manage_dirs_pattern(rke_container_t, rke_opt_t, rke_opt_t)
+manage_files_pattern(rke_container_t, rke_opt_t, rke_opt_t)
+manage_dirs_pattern(rke_container_t, container_var_lib_t, container_var_lib_t)
+manage_files_pattern(rke_container_t, container_var_lib_t, container_var_lib_t)
+manage_dirs_pattern(rke_container_t, container_var_run_t, container_var_run_t)
+manage_files_pattern(rke_container_t, container_var_run_t, container_var_run_t)
+allow rke_container_t self:tcp_socket { accept listen };
+allow rke_container_t container_var_lib_t:file map;
+allow rke_container_t rke_opt_t:file map;
+allow rke_container_t container_var_lib_t:dir { relabelfrom relabelto };
+allow rke_container_t container_var_lib_t:file { relabelfrom relabelto };
+allow rke_container_t rke_opt_t:dir { relabelfrom relabelto };
+allow rke_container_t rke_opt_t:file { relabelfrom relabelto };
+
+########################
+# type rke_network_t   #
+########################
+gen_require(`
+        type container_runtime_t, unconfined_service_t;
+        type iptables_var_run_t;
+        type var_run_t;
+        type kernel_t;
+')
+container_domain_template(rke_network, container)
+virt_sandbox_domain(rke_network_t)
+corenet_unconfined(rke_network_t)
+manage_dirs_pattern(rke_network_t, iptables_var_run_t, iptables_var_run_t)
+manage_files_pattern(rke_network_t, iptables_var_run_t, iptables_var_run_t)
+manage_dirs_pattern(rke_network_t, var_run_t, var_run_t)
+manage_files_pattern(rke_network_t, var_run_t, var_run_t)
+allow rke_network_t kernel_t:system module_request;
+allow rke_network_t kernel_t:unix_dgram_socket sendto;
+allow rke_network_t self:netlink_route_socket nlmsg_write;

--- a/policy/fedora37/scripts/build
+++ b/policy/fedora37/scripts/build
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e -x
+
+cd $(dirname $0)/..
+. ./scripts/version
+
+dnf -y install container-selinux selinux-policy-devel rpm-build
+
+make -f /usr/share/selinux/devel/Makefile rancher.pp
+
+rpmbuild \
+    --define "rancher_selinux_version ${RPM_VERSION}" \
+    --define "rancher_selinux_release ${RPM_RELEASE}" \
+    --define "_sourcedir $PWD" \
+    --define "_specdir $PWD" \
+    --define "_builddir $PWD" \
+    --define "_srcrpmdir ${PWD}/dist/source" \
+    --define "_buildrootdir $PWD/.build" \
+    --define "_rpmdir ${PWD}/dist" \
+    -ba rancher-selinux.spec

--- a/policy/fedora37/scripts/entry
+++ b/policy/fedora37/scripts/entry
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -ex
+
+if [ -e ./policy/fedora37/scripts/"$1" ]; then
+    ./policy/fedora37/scripts/"$@"
+else
+    exec "$@"
+fi
+
+if [ "$DAPPER_UID" -ne "-1" ]; then
+  chown -R $DAPPER_UID:$DAPPER_GID .
+fi

--- a/policy/fedora37/scripts/repo-metadata
+++ b/policy/fedora37/scripts/repo-metadata
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e -x
+
+DIRS=("noarch" "source")
+
+cd $(dirname $0)/..
+. ./scripts/version
+
+dnf install -y createrepo_c
+
+for dir in "${DIRS[@]}"; do
+	echo "Creating repository metadata for $dir"
+	createrepo_c "dist/$dir/"
+done

--- a/policy/fedora37/scripts/sign
+++ b/policy/fedora37/scripts/sign
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -e
+
+DRY_RUN=$1
+SIGN_KEY_EMAIL="ci@rancher.com"
+
+export GPG_TTY=$(tty)
+
+dnf install -y rpm-sign
+
+cd $(dirname $0)/..
+. ./scripts/version
+
+if [ "${DRY_RUN}" = "--dry-run" ]
+then
+  echo "!! Executing in dry-run mode"
+  echo "!! Generating a temporary disposable GPG key to test the signing"
+  echo "!! process (this is only useful when testing PRs)"
+
+  SIGN_KEY_EMAIL="disposable-ci-test-key"
+  TESTING_PRIVATE_KEY_PASS_PHRASE=$(cat /dev/urandom | tr -dc A-Za-z0-9 | head -c20)
+  RPM_CHANNEL="testing"
+
+  gpg --no-tty --quick-gen-key --pinentry-mode loopback --passphrase "$TESTING_PRIVATE_KEY_PASS_PHRASE" --yes "$SIGN_KEY_EMAIL" rsa2048
+
+  TESTING_PRIVATE_KEY=$(gpg --armor --pinentry-mode loopback --passphrase "$TESTING_PRIVATE_KEY_PASS_PHRASE" --export-secret-key "$SIGN_KEY_EMAIL")
+fi
+
+case "$RPM_CHANNEL" in
+  "testing")
+    export PRIVATE_KEY_PASS_PHRASE=$TESTING_PRIVATE_KEY_PASS_PHRASE
+    if ! grep "BEGIN PGP PRIVATE KEY BLOCK" <<<"$TESTING_PRIVATE_KEY" > /dev/null; then
+      echo "TESTING_PRIVATE_KEY not defined, failing rpm sign"
+      exit 1
+    fi
+    echo "Importing GPG private key TESTING_PRIVATE_KEY"
+    gpg --yes --pinentry-mode loopback --batch --passphrase $PRIVATE_KEY_PASS_PHRASE --import - <<< "$TESTING_PRIVATE_KEY"
+    ;;
+  "production")
+    if ! grep "BEGIN PGP PRIVATE KEY BLOCK" <<<"$PRIVATE_KEY" > /dev/null; then
+      echo "PRIVATE_KEY not defined, failing rpm sign"
+      exit 1
+    fi
+    echo "Importing GPG private key PRIVATE_KEY"
+    gpg --yes --batch --pinentry-mode loopback --passphrase $PRIVATE_KEY_PASS_PHRASE --import - <<< "$PRIVATE_KEY"
+    ;;
+  *)
+    echo "RPM_CHANNEL $RPM_CHANNEL does not match one of: [testing, production]"
+    exit 1
+    ;;
+esac
+
+gpg --armor --export --output "$SIGN_KEY_EMAIL" "$SIGN_KEY_EMAIL"
+rpm --import "$SIGN_KEY_EMAIL"
+
+echo "Signing RPMs with ${SIGN_KEY_EMAIL} GPG KEY"
+rpmsign --addsign dist/**/rancher-*.rpm \
+        --define "_gpg_name ${SIGN_KEY_EMAIL}" \
+        --define "_gpgbin /usr/bin/gpg" \
+        --define "__gpg_sign_cmd %{__gpg} gpg \
+                  --batch \
+                  --no-armor \
+                  --pinentry-mode loopback \
+                  --passphrase ${PRIVATE_KEY_PASS_PHRASE} \
+                  -u %{_gpg_name} \
+                  -sbo %{__signature_filename} \
+                  --digest-algo sha256 %{__plaintext_filename}"
+
+echo "Verifying RPMs signatures"
+rpm --checksig --verbose dist/**/rancher-*.rpm

--- a/policy/fedora37/scripts/upload-repo
+++ b/policy/fedora37/scripts/upload-repo
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -e -x
+
+cd $(dirname $0)/..
+. ./scripts/version
+
+# Package required to unzip awscliv2.zip
+dnf install -y unzip
+
+# Install the awscli-v2 from AWS
+curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
+unzip -q awscliv2.zip
+./aws/install
+
+# Test if awscli-v2 is installed 
+if aws --version &> /dev/null; then
+  echo "AWS CLI is installed."
+else
+  echo "AWS CLI not found, exiting."
+  exit 1
+fi
+
+# Prepare and Upload RPMs
+if [ -z "$RPM_CHANNEL" ]; then
+  echo "RPM_CHANNEL not defined, failing rpm upload"
+  exit 1
+fi
+
+TARGET_FC37_S3_PATH="rancher/$RPM_CHANNEL/fedora/37/noarch"
+TARGET_FC37_SOURCE_S3_PATH="rancher/$RPM_CHANNEL/fedora/37/source"
+
+case "$RPM_CHANNEL" in
+  "testing")
+    if [ -z "$TESTING_AWS_S3_BUCKET" ]; then
+      echo "TESTING_AWS_S3_BUCKET not defined, failing rpm upload"
+      exit 1
+    fi
+    if [ -z "$TESTING_AWS_ACCESS_KEY_ID" ]; then
+      echo "TESTING_AWS_ACCESS_KEY_ID not defined, failing rpm upload"
+      exit 1
+    fi
+    if [ -z "$TESTING_AWS_SECRET_ACCESS_KEY" ]; then
+      echo "TESTING_AWS_SECRET_ACCESS_KEY not defined, failing rpm upload"
+      exit 1
+    fi
+    export AWS_ACCESS_KEY_ID=$TESTING_AWS_ACCESS_KEY_ID
+    export AWS_SECRET_ACCESS_KEY=$TESTING_AWS_SECRET_ACCESS_KEY
+    export AWS_S3_BUCKET=$TESTING_AWS_S3_BUCKET
+    ;;
+  "production")
+    if [ -z "$AWS_S3_BUCKET" ]; then
+      echo "AWS_S3_BUCKET not defined, failing rpm upload"
+      exit 1
+    fi
+    if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+      echo "AWS_ACCESS_KEY_ID not defined, failing rpm upload"
+      exit 1
+    fi
+    if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+      echo "AWS_SECRET_ACCESS_KEY not defined, failing rpm upload"
+      exit 1
+    fi
+    ;;
+  *)
+    echo "RPM_CHANNEL $RPM_CHANNEL does not match one of: [testing, production]"
+    exit 1
+    ;;
+esac
+
+echo "Uploading RPMs packages and repo metadata files"
+aws s3 cp dist/noarch/ s3://"$AWS_S3_BUCKET"/"$TARGET_FC37_S3_PATH"/ --recursive
+aws s3 cp dist/source/ s3://"$AWS_S3_BUCKET"/"$TARGET_FC37_SOURCE_S3_PATH"/ --recursive

--- a/policy/fedora37/scripts/version
+++ b/policy/fedora37/scripts/version
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+TREE_STATE=clean
+COMMIT=${COMMIT:-${DRONE_COMMIT:-${GITHUB_SHA:-unknown}}}
+TAG=${TAG:-${DRONE_TAG:-$GITHUB_TAG}}
+
+if [ -d ${DAPPER_SOURCE}/.git ]; then
+    pushd ${DAPPER_SOURCE}
+    if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+        DIRTY="dirty"
+        TREE_STATE=dirty
+    fi
+
+    if [[ "$TREE_STATE" == "clean" && -z "$TAG" ]]; then
+        TAG=$(git tag -l --contains HEAD | head -n 1) # this is going to not work if you have multiple tags pointing to the same commit
+    fi
+
+    COMMIT=$(git log -n3 --pretty=format:"%H %ae" | grep -v ' drone@localhost$' | cut -f1 -d\  | head -1)
+    if [ -z "$COMMIT" ]; then
+        COMMIT=$(git rev-parse HEAD || true)
+    fi
+    popd
+fi
+
+if [[ -n "$TAG" ]]; then
+    if [[ "$TREE_STATE" = "clean" ]]; then
+        VERSION=$TAG # We will only accept the tag as our version if the tree state is clean and the tag is in fact defined.
+    fi
+else
+    VERSION="v0.0~${COMMIT:0:8}${DIRTY}.testing.0"
+fi
+
+# v0.1.testing.1
+
+if ! [[ $VERSION =~ ^v[0-9]+\.[0-9]+[-~a-zA-Z0-9]*\.[a-z]+\.[0-9]+$ ]]; then
+    echo "Version $VERSION does not match our expected format. Exiting."
+    exit 1
+fi
+rpm_version_regex='s/\-/~/g; s/^v([0-9]+\.[0-9]+[-~a-zA-Z0-9]*)\.[a-z]+\.[0-9]+$/\1/;'
+rpm_channel_regex='s/^v[0-9]+\.[0-9]+[-~a-zA-Z0-9]*\.([a-z]+)\.[0-9]+$/\1/;'
+rpm_release_regex='s/^v[0-9]+\.[0-9]+[-~a-zA-Z0-9]*\.[a-z]+\.([0-9]+)$/\1/;'
+
+RPM_VERSION=$(sed -E -e "$rpm_version_regex" <<<"$VERSION")
+RPM_RELEASE=$(sed -E -e "$rpm_release_regex" <<<"$VERSION")
+RPM_CHANNEL=$(sed -E -e "$rpm_channel_regex" <<<"$VERSION")
+
+if [[ "$RPM_CHANNEL" == "$VERSION" ]]; then
+    echo "Unknown RPM_CHANNEL found: $RPM_CHANNEL but defaulting to testing"
+    RPM_CHANNEL="testing"
+fi
+
+case "$RPM_CHANNEL" in
+    "testing"|"production")
+        echo "RPM_CHANNEL matched our expected variants"
+        ;;
+    *)
+        echo "RPM_CHANNEL $RPM_CHANNEL does not match one of: [testing, production]"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
This is a proof of concept which allows RKE to be deployed to SELinux enabled Fedora >= 37


Currently this does not allow kube-apiserver to start because it can't write/append audit logs. Maybe this is related to https://github.com/rancher/rke2-selinux/pull/17/files