### PR TITLE
Use CentOS stream8 instead of centos:8

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -106,7 +106,7 @@ steps:
     path: /var/run/docker.sock
 
 - name: Sign RPM EL8
-  image: centos:7
+  image: quay.io/centos/centos:stream8
   environment:
     PRIVATE_KEY:
       from_secret: private_key
@@ -128,7 +128,7 @@ steps:
     - tag
 
 - name: Yum Repo Upload EL8
-  image: centos:7
+  image: quay.io/centos/centos:stream8
   environment:
     AWS_S3_BUCKET:
       from_secret: aws_s3_bucket

--- a/Dockerfile.centos8.dapper
+++ b/Dockerfile.centos8.dapper
@@ -1,13 +1,6 @@
-FROM centos:8
+FROM quay.io/centos/centos:stream8
 
-# CentOS 8 has reached EOL: https://www.centos.org/centos-linux-eol/
-# Therefore, we need to switch the mirrorlist for the appstream repo
-#
-# point to vault.epel.cloud
-# https://serverfault.com/questions/1093922/failing-to-run-yum-update-in-centos-8/1093928#1093928
-RUN pushd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* && popd
-
-RUN yum install -y epel-release && yum -y install container-selinux selinux-policy-devel yum-utils rpm-build git jq
+RUN yum install -y epel-release && yum -y install container-selinux selinux-policy-devel yum-utils rpm-build git
 
 ENV DAPPER_SOURCE /source
 ENV DAPPER_OUTPUT ./dist

--- a/policy/centos8/rancher.te
+++ b/policy/centos8/rancher.te
@@ -2,6 +2,7 @@ policy_module(rancher, 1.0.0)
 
 gen_require(`
     type container_runtime_t, unconfined_service_t;
+    type container_file_t;
 ')
 
 ########################
@@ -14,7 +15,7 @@ gen_require(`
         class file { getaddr open read };
         class lnk_file { getattr read };
 ')
-container_domain_template(rke_kubereader)
+container_domain_template(rke_kubereader, container)
 virt_sandbox_domain(rke_kubereader_t)
 corenet_unconfined(rke_kubereader_t)
 allow rke_kubereader_t kubernetes_file_t:dir { open read search };
@@ -33,7 +34,7 @@ gen_require(`
         class file { open read };
         class lnk_file { getattr read };
 ')
-container_domain_template(rke_logreader)
+container_domain_template(rke_logreader, container)
 virt_sandbox_domain(rke_logreader_t)
 corenet_unconfined(rke_logreader_t)
 allow rke_logreader_t container_log_t:dir { open read search };
@@ -60,7 +61,7 @@ gen_require(`
 ')
 type rke_opt_t;
 files_type(rke_opt_t)
-container_domain_template(rke_container)
+container_domain_template(rke_container, container)
 virt_sandbox_domain(rke_container_t)
 corenet_unconfined(rke_container_t)
 manage_dirs_pattern(rke_container_t, container_var_lib_t, container_var_lib_t)
@@ -92,7 +93,7 @@ gen_require(`
         type var_run_t;
         type kernel_t;
 ')
-container_domain_template(rke_network)
+container_domain_template(rke_network, container)
 virt_sandbox_domain(rke_network_t)
 corenet_unconfined(rke_network_t)
 manage_dirs_pattern(rke_network_t, iptables_var_run_t, iptables_var_run_t)


### PR DESCRIPTION
- Move `centos:7` images to `quay.io/centos/centos:stream8` for EL8.
- Remove unneeded `jq` package from `Dockerfile.centos8.dapper`.
- Backport https://github.com/rancher/rancher-selinux/pull/14 for EL8 due to change in the base image.