### PR TITLE
Add centos9 support to rancher-selinux

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -180,6 +180,96 @@ volumes:
     path: /var/run/docker.sock
 ---
 kind: pipeline
+name: RPM Build EL9
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: Build EL9
+  image: rancher/dapper:v0.6.0
+  commands:
+  - dapper -f Dockerfile.centos9.dapper policy/centos9/scripts/build
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+
+- name: Sign RPM EL9
+  image: quay.io/centos/centos:stream9
+  environment:
+    PRIVATE_KEY:
+      from_secret: private_key
+    PRIVATE_KEY_PASS_PHRASE:
+      from_secret: private_key_pass_phrase
+    TESTING_PRIVATE_KEY:
+      from_secret: testing_private_key
+    TESTING_PRIVATE_KEY_PASS_PHRASE:
+      from_secret: testing_private_key_pass_phrase
+  commands:
+  - policy/centos9/scripts/sign
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag
+
+- name: Yum Repo Upload EL9
+  image: quay.io/centos/centos:stream9
+  environment:
+    AWS_S3_BUCKET:
+      from_secret: aws_s3_bucket
+    AWS_ACCESS_KEY_ID:
+      from_secret: aws_access_key_id
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: aws_secret_access_key
+    TESTING_AWS_S3_BUCKET:
+      from_secret: testing_aws_s3_bucket
+    TESTING_AWS_ACCESS_KEY_ID:
+      from_secret: testing_aws_access_key_id
+    TESTING_AWS_SECRET_ACCESS_KEY:
+      from_secret: testing_aws_secret_access_key
+  commands:
+  - policy/centos9/scripts/upload-repo
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag
+
+- name: GitHub Release EL9
+  image: ibuildthecloud/github-release:v0.0.1
+  settings:
+    api_key:
+      from_secret: github_token
+    prerelease: true
+    checksum:
+    - sha256
+    checksum_file: CHECKSUMsum-centos9-noarch.txt
+    checksum_flatten: true
+    files:
+    - "dist/centos9/**/*.rpm"
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag
+
+volumes:
+- name: docker
+  host:
+    path: /var/run/docker.sock
+---
+kind: pipeline
 name: RPM Build MicroOS
 
 platform:

--- a/Dockerfile.centos9.dapper
+++ b/Dockerfile.centos9.dapper
@@ -1,0 +1,11 @@
+FROM quay.io/centos/centos:stream9
+
+RUN yum install -y epel-release && yum -y install container-selinux selinux-policy-devel yum-utils rpm-build git
+
+ENV DAPPER_SOURCE /source
+ENV DAPPER_OUTPUT ./dist
+ENV DAPPER_ENV COMBARCH DRONE_TAG TAG
+ENV HOME ${DAPPER_SOURCE}
+WORKDIR ${DAPPER_SOURCE}
+
+ENTRYPOINT ["./policy/centos9/scripts/entry"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CENTOS7_TARGETS := $(addprefix centos7-,$(shell ls policy/centos7/scripts))
 CENTOS8_TARGETS := $(addprefix centos8-,$(shell ls policy/centos8/scripts))
+CENTOS9_TARGETS := $(addprefix centos9-,$(shell ls policy/centos9/scripts))
 MICROOS_TARGETS := $(addprefix microos-,$(shell ls policy/microos/scripts))
 
 .dapper:
@@ -14,6 +15,9 @@ $(CENTOS7_TARGETS): .dapper
 
 $(CENTOS8_TARGETS): .dapper
 	./.dapper -f Dockerfile.centos8.dapper $(@:centos8-%=%)
+
+$(CENTOS9_TARGETS): .dapper
+	./.dapper -f Dockerfile.centos9.dapper $(@:centos9-%=%)
 
 $(MICROOS_TARGETS): .dapper
 	./.dapper -f Dockerfile.microos.dapper $(@:microos-%=%)

--- a/policy/centos9/rancher-selinux.spec
+++ b/policy/centos9/rancher-selinux.spec
@@ -1,0 +1,54 @@
+# vim: sw=4:ts=4:et
+
+%define selinux_policyver 3.13.1-252
+%define container_policyver 2.144.0-1
+
+%define relabel_files() \
+mkdir -p /var/lib/rancher/rke /etc/kubernetes /opt/rke; \
+restorecon -R /var/lib/rancher /etc/kubernetes /opt/rke;
+
+Name:   rancher-selinux
+Version:	%{rancher_selinux_version}
+Release:	%{rancher_selinux_release}.el9
+Summary:	SELinux policy module for Rancher
+
+Group:	System Environment/Base
+License:	ASL 2.0
+URL:		http://rancher.com
+Source0:	rancher.pp
+
+Requires: policycoreutils, libselinux-utils
+Requires(post): selinux-policy-base >= %{selinux_policyver}, policycoreutils, container-selinux >= %{container_policyver}
+Requires(postun): policycoreutils
+
+BuildArch: noarch
+
+%description
+This package installs and sets up the SELinux policy security module for Rancher.
+
+%install
+install -d %{buildroot}%{_datadir}/selinux/packages
+install -m 644 %{SOURCE0} %{buildroot}%{_datadir}/selinux/packages
+
+
+%post
+semodule -n -i %{_datadir}/selinux/packages/rancher.pp
+if /usr/sbin/selinuxenabled ; then
+    /usr/sbin/load_policy
+    %relabel_files
+fi;
+exit 0
+
+%postun
+if [ $1 -eq 0 ]; then
+    semodule -n -r rancher
+    if /usr/sbin/selinuxenabled ; then
+       /usr/sbin/load_policy
+    fi;
+fi;
+exit 0
+
+%files
+%attr(0600,root,root) %{_datadir}/selinux/packages/rancher.pp
+
+%changelog

--- a/policy/centos9/rancher.fc
+++ b/policy/centos9/rancher.fc
@@ -1,0 +1,2 @@
+/var/lib/rancher/rke(/.*)?                                              gen_context(system_u:object_r:container_var_lib_t,s0)
+/opt/rke(/.*)?                                                          gen_context(system_u:object_r:rke_opt_t,s0)

--- a/policy/centos9/rancher.te
+++ b/policy/centos9/rancher.te
@@ -1,0 +1,105 @@
+policy_module(rancher, 1.0.0)
+
+gen_require(`
+    type container_runtime_t, unconfined_service_t;
+    type container_file_t;
+')
+
+########################
+# type rke_kubereader_t #
+########################
+gen_require(`
+        type container_runtime_t, unconfined_service_t;
+        type kubernetes_file_t;
+        class dir { open read search };
+        class file { getaddr open read };
+        class lnk_file { getattr read };
+')
+container_domain_template(rke_kubereader, container)
+virt_sandbox_domain(rke_kubereader_t)
+corenet_unconfined(rke_kubereader_t)
+allow rke_kubereader_t kubernetes_file_t:dir { open read search };
+allow rke_kubereader_t kubernetes_file_t:file { getattr open read };
+allow rke_kubereader_t kubernetes_file_t:lnk_file { getattr read };
+
+########################
+# type rke_logreader_t #
+########################
+gen_require(`
+        type container_runtime_t, unconfined_service_t;
+        type container_log_t;
+        type syslogd_var_run_t;
+        type var_log_t;
+        class dir { read search };
+        class file { open read };
+        class lnk_file { getattr read };
+')
+container_domain_template(rke_logreader, container)
+virt_sandbox_domain(rke_logreader_t)
+corenet_unconfined(rke_logreader_t)
+allow rke_logreader_t container_log_t:dir { open read search };
+allow rke_logreader_t container_log_t:lnk_file { getattr read };
+allow rke_logreader_t container_log_t:file { getattr open read };
+allow rke_logreader_t container_var_lib_t:dir search;
+allow rke_logreader_t container_var_lib_t:file { getattr open read };
+allow rke_logreader_t container_var_lib_t:lnk_file { getattr read };
+allow rke_logreader_t syslogd_var_run_t:dir read;
+allow rke_logreader_t syslogd_var_run_t:file { getattr map open read };
+allow rke_logreader_t var_log_t:dir read;
+allow rke_logreader_t var_log_t:file { getattr map open read };
+
+########################
+# type rke_container_t #
+########################
+gen_require(`
+        type container_runtime_t, unconfined_service_t;
+        type container_log_t;
+        type kubernetes_file_t;
+        type container_var_run_t;
+        class dir { read search };
+        class file { open read };
+')
+type rke_opt_t;
+files_type(rke_opt_t)
+container_domain_template(rke_container, container)
+virt_sandbox_domain(rke_container_t)
+corenet_unconfined(rke_container_t)
+manage_dirs_pattern(rke_container_t, container_var_lib_t, container_var_lib_t)
+manage_files_pattern(rke_container_t, container_var_lib_t, container_var_lib_t)
+manage_dirs_pattern(rke_container_t, container_log_t, container_log_t)
+manage_files_pattern(rke_container_t, container_log_t, container_log_t)
+manage_dirs_pattern(rke_container_t, kubernetes_file_t, kubernetes_file_t)
+manage_files_pattern(rke_container_t, kubernetes_file_t, kubernetes_file_t)
+manage_dirs_pattern(rke_container_t, rke_opt_t, rke_opt_t)
+manage_files_pattern(rke_container_t, rke_opt_t, rke_opt_t)
+manage_dirs_pattern(rke_container_t, container_var_lib_t, container_var_lib_t)
+manage_files_pattern(rke_container_t, container_var_lib_t, container_var_lib_t)
+manage_dirs_pattern(rke_container_t, container_var_run_t, container_var_run_t)
+manage_files_pattern(rke_container_t, container_var_run_t, container_var_run_t)
+allow rke_container_t self:tcp_socket { accept listen };
+allow rke_container_t container_var_lib_t:file map;
+allow rke_container_t rke_opt_t:file map;
+allow rke_container_t container_var_lib_t:dir { relabelfrom relabelto };
+allow rke_container_t container_var_lib_t:file { relabelfrom relabelto };
+allow rke_container_t rke_opt_t:dir { relabelfrom relabelto };
+allow rke_container_t rke_opt_t:file { relabelfrom relabelto };
+
+########################
+# type rke_network_t   #
+########################
+gen_require(`
+        type container_runtime_t, unconfined_service_t;
+        type iptables_var_run_t;
+        type var_run_t;
+        type kernel_t;
+')
+container_domain_template(rke_network, container)
+virt_sandbox_domain(rke_network_t)
+corenet_unconfined(rke_network_t)
+manage_dirs_pattern(rke_network_t, iptables_var_run_t, iptables_var_run_t)
+manage_files_pattern(rke_network_t, iptables_var_run_t, iptables_var_run_t)
+manage_dirs_pattern(rke_network_t, var_run_t, var_run_t)
+manage_files_pattern(rke_network_t, var_run_t, var_run_t)
+allow rke_network_t kernel_t:system module_request;
+allow rke_network_t kernel_t:unix_dgram_socket sendto;
+allow rke_network_t self:netlink_route_socket nlmsg_write;

--- a/policy/centos9/scripts/build
+++ b/policy/centos9/scripts/build
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e -x
+
+cd $(dirname $0)/..
+. ./scripts/version
+
+make -f /usr/share/selinux/devel/Makefile rancher.pp
+
+rpmbuild \
+    --define "rancher_selinux_version ${RPM_VERSION}" \
+    --define "rancher_selinux_release ${RPM_RELEASE}" \
+    --define "_sourcedir $PWD" \
+    --define "_specdir $PWD" \
+    --define "_builddir $PWD" \
+    --define "_srcrpmdir ${PWD}/dist/source" \
+    --define "_buildrootdir $PWD/.build" \
+    --define "_rpmdir ${PWD}/dist" \
+    -ba rancher-selinux.spec
+
+mkdir -p /source/dist/centos9
+cp -r dist/* /source/dist/centos9

--- a/policy/centos9/scripts/entry
+++ b/policy/centos9/scripts/entry
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -ex
+
+if [ -e ./policy/centos9/scripts/"$1" ]; then
+    ./policy/centos9/scripts/"$@"
+else
+    exec "$@"
+fi
+
+if [ "$DAPPER_UID" -ne "-1" ]; then
+  chown -R $DAPPER_UID:$DAPPER_GID .
+fi

--- a/policy/centos9/scripts/sign
+++ b/policy/centos9/scripts/sign
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e -x
+
+yum install -y rpm-sign expect git
+
+pushd $(dirname $0)/..
+. ./scripts/version
+popd
+
+cat <<\EOF >~/.rpmmacros 
+%_signature gpg
+%_gpg_name ci@rancher.com
+EOF
+
+case "$RPM_CHANNEL" in
+  "testing")
+    export PRIVATE_KEY_PASS_PHRASE=$TESTING_PRIVATE_KEY_PASS_PHRASE
+    if ! grep "BEGIN PGP PRIVATE KEY BLOCK" <<<"$TESTING_PRIVATE_KEY"; then
+      echo "TESTING_PRIVATE_KEY not defined, failing rpm sign"
+      exit 1
+    fi
+    gpg --import - <<<"$TESTING_PRIVATE_KEY"
+    ;;
+  "production")
+    if ! grep "BEGIN PGP PRIVATE KEY BLOCK" <<<"$PRIVATE_KEY"; then
+      echo "PRIVATE_KEY not defined, failing rpm sign"
+      exit 1
+    fi
+    gpg --import - <<<"$PRIVATE_KEY"
+    ;;
+  *)
+    echo "RPM_CHANNEL $RPM_CHANNEL does not match one of: [testing, production]"
+    exit 1
+    ;;
+esac
+
+expect <<EOF
+set timeout 60
+spawn sh -c "rpmsign --addsign dist/centos9/**/rancher-*.rpm"
+expect "Enter pass phrase:"
+send -- "$PRIVATE_KEY_PASS_PHRASE\r"
+expect eof
+lassign [wait] _ _ _ code
+exit \$code
+EOF

--- a/policy/centos9/scripts/upload-repo
+++ b/policy/centos9/scripts/upload-repo
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -e -x
+
+pushd $(dirname $0)/..
+. ./scripts/version
+popd
+
+yum install -y epel-release
+yum install -y git python2-pip python-deltarpm
+pip install boto3==1.17.112
+pip install --cache-dir=/var/cache/pip/ \
+  git+git://github.com/Voronenko/rpm-s3.git@5695c6ad9a08548141d3713328e1bd3f533d137e
+
+if [ -z "$RPM_CHANNEL" ]; then
+  echo "RPM_CHANNEL not defined, failing rpm upload"
+  exit 1
+fi
+
+TARGET_EL9_S3_PATH="rancher/$RPM_CHANNEL/centos/9/noarch"
+TARGET_EL9_SOURCE_S3_PATH="rancher/$RPM_CHANNEL/centos/9/source"
+
+case "$RPM_CHANNEL" in
+  "testing")
+    if [ -z "$TESTING_AWS_S3_BUCKET" ]; then
+      echo "TESTING_AWS_S3_BUCKET not defined, failing rpm upload"
+      exit 1
+    fi
+    if [ -z "$TESTING_AWS_ACCESS_KEY_ID" ]; then
+      echo "TESTING_AWS_ACCESS_KEY_ID not defined, failing rpm upload"
+      exit 1
+    fi
+    if [ -z "$TESTING_AWS_SECRET_ACCESS_KEY" ]; then
+      echo "TESTING_AWS_SECRET_ACCESS_KEY not defined, failing rpm upload"
+      exit 1
+    fi
+    export AWS_ACCESS_KEY_ID=$TESTING_AWS_ACCESS_KEY_ID
+    export AWS_SECRET_ACCESS_KEY=$TESTING_AWS_SECRET_ACCESS_KEY
+    export AWS_S3_BUCKET=$TESTING_AWS_S3_BUCKET
+    ;;
+  "production")
+    if [ -z "$AWS_S3_BUCKET" ]; then
+      echo "AWS_S3_BUCKET not defined, failing rpm upload"
+      exit 1
+    fi
+    if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+      echo "AWS_ACCESS_KEY_ID not defined, failing rpm upload"
+      exit 1
+    fi
+    if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+      echo "AWS_SECRET_ACCESS_KEY not defined, failing rpm upload"
+      exit 1
+    fi
+    ;;
+  *)
+    echo "RPM_CHANNEL $RPM_CHANNEL does not match one of: [testing, production]"
+    exit 1
+    ;;
+esac
+
+rpm-s3 --bucket $AWS_S3_BUCKET -p $TARGET_EL9_S3_PATH --keep 100000 dist/centos9/noarch/rancher-*.rpm
+rpm-s3 --bucket $AWS_S3_BUCKET -p $TARGET_EL9_SOURCE_S3_PATH --keep 100000 dist/centos9/source/rancher-*src.rpm
+

--- a/policy/centos9/scripts/version
+++ b/policy/centos9/scripts/version
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+TREE_STATE=clean
+COMMIT=${COMMIT:-${DRONE_COMMIT:-${GITHUB_SHA:-unknown}}}
+TAG=${TAG:-${DRONE_TAG:-$GITHUB_TAG}}
+
+if [ -d ${DAPPER_SOURCE}/.git ]; then
+    pushd ${DAPPER_SOURCE}
+    if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+        DIRTY="dirty"
+        TREE_STATE=dirty
+    fi
+
+    if [[ "$TREE_STATE" == "clean" && -z "$TAG" ]]; then
+        TAG=$(git tag -l --contains HEAD | head -n 1) # this is going to not work if you have multiple tags pointing to the same commit
+    fi
+
+    COMMIT=$(git log -n3 --pretty=format:"%H %ae" | grep -v ' drone@localhost$' | cut -f1 -d\  | head -1)
+    if [ -z "$COMMIT" ]; then
+        COMMIT=$(git rev-parse HEAD || true)
+    fi
+    popd
+fi
+
+if [[ -n "$TAG" ]]; then
+    if [[ "$TREE_STATE" = "clean" ]]; then
+        VERSION=$TAG # We will only accept the tag as our version if the tree state is clean and the tag is in fact defined.
+    fi
+else
+    VERSION="v0.0~${COMMIT:0:8}${DIRTY}.testing.0"
+fi
+
+# v0.1.testing.1
+
+if ! [[ $VERSION =~ ^v[0-9]+\.[0-9]+[-~a-zA-Z0-9]*\.[a-z]+\.[0-9]+$ ]]; then
+    echo "Version $VERSION does not match our expected format. Exiting."
+    exit 1
+fi
+rpm_version_regex='s/\-/~/g; s/^v([0-9]+\.[0-9]+[-~a-zA-Z0-9]*)\.[a-z]+\.[0-9]+$/\1/;'
+rpm_channel_regex='s/^v[0-9]+\.[0-9]+[-~a-zA-Z0-9]*\.([a-z]+)\.[0-9]+$/\1/;'
+rpm_release_regex='s/^v[0-9]+\.[0-9]+[-~a-zA-Z0-9]*\.[a-z]+\.([0-9]+)$/\1/;'
+
+RPM_VERSION=$(sed -E -e "$rpm_version_regex" <<<"$VERSION")
+RPM_RELEASE=$(sed -E -e "$rpm_release_regex" <<<"$VERSION")
+RPM_CHANNEL=$(sed -E -e "$rpm_channel_regex" <<<"$VERSION")
+
+if [[ "$RPM_CHANNEL" == "$VERSION" ]]; then
+    echo "Unknown RPM_CHANNEL found: $RPM_CHANNEL but defaulting to testing"
+    RPM_CHANNEL="testing"
+fi
+
+case "$RPM_CHANNEL" in
+    "testing"|"production")
+        echo "RPM_CHANNEL matched our expected variants"
+        ;;
+    *)
+        echo "RPM_CHANNEL $RPM_CHANNEL does not match one of: [testing, production]"
+        exit 1
+        ;;
+esac 


### PR DESCRIPTION
This PR adds  `centos-stream9` (EL9) support to rancher-selinux .

- image: quay.io/centos/centos:stream9

Here is the outcome of the policy compilation and installation, after the build:

```
bash-5.1# cat /etc/*release
CentOS Stream release 9
NAME="CentOS Stream"
VERSION="9"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="9"
PLATFORM_ID="platform:el9"
PRETTY_NAME="CentOS Stream 9"
ANSI_COLOR="0;31"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:centos:centos:9"
HOME_URL="https://centos.org/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux 9"
REDHAT_SUPPORT_PRODUCT_VERSION="CentOS Stream"
CentOS Stream release 9
CentOS Stream release 9
bash-5.1# ls
CODEOWNERS		   Dockerfile.centos9.dapper		Dockerfile.microos.dapper  README.md
Dockerfile.centos7.dapper  Dockerfile.centos9.dapper2218901142	LICENSE			   policy
Dockerfile.centos8.dapper  Dockerfile.centos9.dapper2819780759	Makefile
bash-5.1# cd policy/
bash-5.1# ls
centos7  centos8  centos9  microos
bash-5.1# cd centos9/
bash-5.1# ls
rancher-selinux.spec  rancher.fc  rancher.te  scripts
bash-5.1# make -f /usr/share/selinux/devel/Makefile rancher.pp
Compiling targeted rancher module
Creating targeted rancher.pp policy package
rm tmp/rancher.mod.fc tmp/rancher.mod
bash-5.1# semodule -i rancher.pp
libsemanage.semanage_rename: WARNING: rename(/var/lib/selinux/targeted/active, /var/lib/selinux/targeted/previous) failed: Invalid cross-device link, fall back to non-atomic semanage_copy_dir_flags()
```

Tracking issue in Rancher https://github.com/rancher/rancher/issues/43146.