### PR TITLE
Improve Centos9's rpms signing and upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ $(CENTOS9_TARGETS): .dapper
 $(MICROOS_TARGETS): .dapper
 	./.dapper -f Dockerfile.microos.dapper $(@:microos-%=%)
 
-.PHONY: $(CENTOS7_TARGETS) $(CENTOS8_TARGETS) $(MICROOS_TARGETS)
+.PHONY: $(CENTOS7_TARGETS) $(CENTOS8_TARGETS) $(CENTOS9_TARGETS) $(MICROOS_TARGETS)

--- a/policy/centos9/scripts/sign
+++ b/policy/centos9/scripts/sign
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e -x
 
-yum install -y rpm-sign expect git
+yum install -y rpm-sign expect pinentry
 
 pushd $(dirname $0)/..
 . ./scripts/version

--- a/policy/centos9/scripts/upload-repo
+++ b/policy/centos9/scripts/upload-repo
@@ -6,10 +6,8 @@ pushd $(dirname $0)/..
 popd
 
 yum install -y epel-release
-yum install -y git python2-pip python-deltarpm
-pip install boto3==1.17.112
-pip install --cache-dir=/var/cache/pip/ \
-  git+git://github.com/Voronenko/rpm-s3.git@5695c6ad9a08548141d3713328e1bd3f533d137e
+yum install -y python3-pip
+pip install awscli==1.29.67
 
 if [ -z "$RPM_CHANNEL" ]; then
   echo "RPM_CHANNEL not defined, failing rpm upload"
@@ -57,6 +55,5 @@ case "$RPM_CHANNEL" in
     ;;
 esac
 
-rpm-s3 --bucket $AWS_S3_BUCKET -p $TARGET_EL9_S3_PATH --keep 100000 dist/centos9/noarch/rancher-*.rpm
-rpm-s3 --bucket $AWS_S3_BUCKET -p $TARGET_EL9_SOURCE_S3_PATH --keep 100000 dist/centos9/source/rancher-*src.rpm
-
+aws s3 cp /source/dist/centos9/noarch/rancher-*.rpm $AWS_S3_BUCKET/$TARGET_EL9_S3_PATH/
+aws s3 cp /source/dist/centos9/source/rancher-*src.rpm $AWS_S3_BUCKET/$TARGET_EL9_SOURCE_S3_PATH/

--- a/policy/centos9/scripts/upload-repo
+++ b/policy/centos9/scripts/upload-repo
@@ -5,10 +5,20 @@ pushd $(dirname $0)/..
 . ./scripts/version
 popd
 
-yum install -y epel-release
-yum install -y python3-pip
-pip install awscli==1.29.67
+# Install the awscli-v2 from AWS
+curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+./aws/install
 
+# Test if awscli-v2 is installed 
+if aws --version &> /dev/null; then
+  echo "AWS CLI is installed."
+else
+  echo "AWS CLI not found, exiting."
+  exit 1
+fi
+
+# Prepare and Upload RPMs
 if [ -z "$RPM_CHANNEL" ]; then
   echo "RPM_CHANNEL not defined, failing rpm upload"
   exit 1


### PR DESCRIPTION
This PR improves the following in rancher-selinux Centos9 (following [errors](https://drone-publish.rancher.io/rancher/rancher-selinux/92) in drone-publish):

- scripts/sign : install pinentry package
- scripts/upload-repo: Replace rpm-s3 with [awscli v2](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
- Makefile add PHONY for Centos9

Note: `rpm-s3` still uses python2 and is not maintained as well as `awscli`.