### PR TITLE
Update gpg import with --batch and change expect prompt

### DIFF
--- a/policy/centos9/scripts/sign
+++ b/policy/centos9/scripts/sign
@@ -19,14 +19,14 @@ case "$RPM_CHANNEL" in
       echo "TESTING_PRIVATE_KEY not defined, failing rpm sign"
       exit 1
     fi
-    gpg --import - <<<"$TESTING_PRIVATE_KEY"
+    gpg --batch --import - <<< "$TESTING_PRIVATE_KEY" 
     ;;
   "production")
     if ! grep "BEGIN PGP PRIVATE KEY BLOCK" <<<"$PRIVATE_KEY"; then
       echo "PRIVATE_KEY not defined, failing rpm sign"
       exit 1
     fi
-    gpg --import - <<<"$PRIVATE_KEY"
+    gpg --batch --import - <<< "$PRIVATE_KEY" 
     ;;
   *)
     echo "RPM_CHANNEL $RPM_CHANNEL does not match one of: [testing, production]"
@@ -37,7 +37,7 @@ esac
 expect <<EOF
 set timeout 60
 spawn sh -c "rpmsign --addsign dist/centos9/**/rancher-*.rpm"
-expect "Enter pass phrase:"
+expect "Passphrase:"
 send -- "$PRIVATE_KEY_PASS_PHRASE\r"
 expect eof
 lassign [wait] _ _ _ code


### PR DESCRIPTION
This PR fixes the following signing errors:

1. Since GPGv2, the use --import with --batch is required to avoid `error sending to agent: Inappropriate ioctl for device`
2. Update`expect` passphrase prompt content from `Enter pass phrase:` (works in Centos7) to `Passphrase:`, to be able to pass the $PRIVATE_KEY_PASS_PHRASE during the `rpmsign`.

#### Centos7 and older's prompt:
```
[root@808cee5de232 code]# rpmsign --addsign /source/dist/centos9/**/rancher-*.rpm
Enter pass phrase:
```
#### Centos8 and newer's prompt:
![image](https://github.com/rancher/rancher-selinux/assets/12878731/50ed3b97-99b1-4036-a252-30e7ba4881da)


