### PR TITLE
Create and upload repo metadata

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -191,9 +191,6 @@ steps:
   image: quay.io/centos/centos:stream9
   commands:
   - policy/centos9/scripts/build
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
 
 - name: Sign RPM EL9 (dry-run)
   image: quay.io/centos/centos:stream9
@@ -224,6 +221,11 @@ steps:
     - refs/tags/*
     event:
     - tag
+
+- name: Create repo metadata for EL9
+  image: quay.io/centos/centos:stream9
+  commands:
+  - policy/centos9/scripts/repo-metadata
 
 - name: Upload RPM EL9
   image: quay.io/centos/centos:stream9
@@ -271,11 +273,6 @@ steps:
     - refs/tags/*
     event:
     - tag
-
-volumes:
-- name: docker
-  host:
-    path: /var/run/docker.sock
 
 ---
 kind: pipeline

--- a/policy/centos9/scripts/build
+++ b/policy/centos9/scripts/build
@@ -5,7 +5,7 @@ cd $(dirname $0)/..
 . ./scripts/version
 
 yum install -y epel-release
-yum install -y container-selinux selinux-policy-devel yum-utils rpm-build # git
+yum install -y container-selinux selinux-policy-devel yum-utils rpm-build
 
 make -f /usr/share/selinux/devel/Makefile rancher.pp
 

--- a/policy/centos9/scripts/repo-metadata
+++ b/policy/centos9/scripts/repo-metadata
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e -x
+
+DIRS=("noarch" "source")
+
+cd $(dirname $0)/..
+. ./scripts/version
+
+yum install -y createrepo_c
+
+for dir in "${DIRS[@]}"; do
+	echo "Creating repository metadata for $dir"
+	createrepo "dist/$dir/"
+done
+

--- a/policy/centos9/scripts/upload-repo
+++ b/policy/centos9/scripts/upload-repo
@@ -9,7 +9,7 @@ yum install -y unzip
 
 # Install the awscli-v2 from AWS
 curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
-unzip awscliv2.zip
+unzip -q awscliv2.zip
 ./aws/install
 
 # Test if awscli-v2 is installed 
@@ -67,6 +67,7 @@ case "$RPM_CHANNEL" in
     ;;
 esac
 
-aws s3 cp dist/noarch/rancher-*.rpm    s3://"$AWS_S3_BUCKET"/"$TARGET_EL9_S3_PATH"/
-aws s3 cp dist/source/rancher-*src.rpm s3://"$AWS_S3_BUCKET"/"$TARGET_EL9_SOURCE_S3_PATH"/
+echo "Uploading RPMs packages and repo metadata files"
+aws s3 cp dist/noarch/ s3://"$AWS_S3_BUCKET"/"$TARGET_EL9_S3_PATH"/ --recursive
+aws s3 cp dist/source/ s3://"$AWS_S3_BUCKET"/"$TARGET_EL9_SOURCE_S3_PATH"/ --recursive
 


### PR DESCRIPTION
This PR automates the creation and upload of the repo metadata files. The created repodata files are required for the RPM repo to work, otherwise yum/dnf can't pull the Rancher SELinux RPM package. The files are created for both `noarch` and `source` and are similar to:

```
07a33d9e4a0a369f2012f75ce363b7705a3b39113890e787ca11fcf5d0dcec04-filelists.sqlite.bz2
3e5d646fb162808992b2f5b3a8fc3491881eac6c6d547c3470745144f29215fe-other.xml.gz
92639d8ad4b78a72ad6713bd0d77a6368e155c774b272eb7a6ca4762ffa9c635-primary.xml.gz
a1b73c31bde9e6b823a7831c9c0f2f927e7b2d2307e5d9907091164dfb5f775a-filelists.xml.gz
bec1c9dff50e83e03076d3dbff1cc29bd7a856b6ac28f6af8ead62a97724ebc3-other.sqlite.bz2
daad01390cec8b92843c94ea0402e40f98a0127b490a1a33e91c3e06227a24ed-primary.sqlite.bz2
repomd.xml
```

The upload happens at the same time that the RPM package is uploaded.

Further improvements that must be done on follow-up PRs:
1. Sign the generated artifacts.
2. Implementing a caching validation to avoid recreating the repodata files if the RPM package hasn't changed.