### PR TITLE
Fix MicroOS/Centos7 pipeline issues

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -353,7 +353,7 @@ steps:
     - tag
 
 - name: GitHub Release RPM MicroOS
-  image: opensuse/tumbleweed
+  image: ibuildthecloud/github-release:v0.0.1
   settings:
     api_key:
       from_secret: github_token

--- a/.drone.yml
+++ b/.drone.yml
@@ -66,7 +66,7 @@ steps:
     - tag
 
 - name: GitHub Release RPM EL7
-  image: ibuildthecloud/github-release:v0.0.1
+  image: plugins/github-release
   settings:
     api_key:
       from_secret: github_token
@@ -161,7 +161,7 @@ steps:
     - tag
 
 - name: GitHub Release RPM EL8
-  image: ibuildthecloud/github-release:v0.0.1
+  image: plugins/github-release
   settings:
     api_key:
       from_secret: github_token
@@ -257,7 +257,7 @@ steps:
     - tag
 
 - name: GitHub Release RPM EL9
-  image: ibuildthecloud/github-release:v0.0.1
+  image: plugins/github-release
   settings:
     api_key:
       from_secret: github_token
@@ -353,7 +353,7 @@ steps:
     - tag
 
 - name: GitHub Release RPM MicroOS
-  image: ibuildthecloud/github-release:v0.0.1
+  image: plugins/github-release
   settings:
     api_key:
       from_secret: github_token

--- a/policy/centos7/scripts/sign
+++ b/policy/centos7/scripts/sign
@@ -36,7 +36,7 @@ esac
 
 expect <<EOF
 set timeout 60
-spawn sh -c "rpmsign --addsign dist/centos7/**/rancher-*.rpm"
+spawn sh -c "rpmsign --addsign dist/**/rancher-*.rpm"
 expect "Enter pass phrase:"
 send -- "$PRIVATE_KEY_PASS_PHRASE\r"
 expect eof

--- a/policy/microos/scripts/build
+++ b/policy/microos/scripts/build
@@ -18,6 +18,3 @@ rpmbuild \
     --define "_buildrootdir $PWD/.build" \
     --define "_rpmdir ${PWD}/dist" \
     -ba rancher-selinux.spec
-
-mkdir -p /source/dist/microos
-cp -r dist/* /source/dist/microos


### PR DESCRIPTION
This PR fixes the following issues:

- Centos7 -> rpms location path in scripts/sign
- MicroOS -> Remove useless commands in scripts/build
- All -> Change GH release image to plugins/github-release