### PR TITLE
Replace kubernetes_file_t with rke_etc_t for centos7

### DIFF
--- a/policy/centos7/rancher.te
+++ b/policy/centos7/rancher.te
@@ -9,7 +9,7 @@ gen_require(`
 ########################
 gen_require(`
         type container_runtime_t, unconfined_service_t;
-        type kubernetes_file_t;
+	type rke_etc_t;
         class dir { open read search };
         class file { getaddr open read };
         class lnk_file { getattr read };
@@ -17,9 +17,9 @@ gen_require(`
 container_domain_template(rke_kubereader)
 virt_sandbox_domain(rke_kubereader_t)
 corenet_unconfined(rke_kubereader_t)
-allow rke_kubereader_t kubernetes_file_t:dir { open read search };
-allow rke_kubereader_t kubernetes_file_t:file { getattr open read };
-allow rke_kubereader_t kubernetes_file_t:lnk_file { getattr read };
+allow rke_kubereader_t rke_etc_t:dir { open read search };
+allow rke_kubereader_t rke_etc_t:file { getattr open read };
+allow rke_kubereader_t rke_etc_t:lnk_file { getattr read };
 
 ########################
 # type rke_logreader_t #


### PR DESCRIPTION
This PR replaces `kubernetes_file_t` with `rke_etc_t` type in rancher.te for centos7 (only).

**Context:** Centos7 uses by default `container-selinux-2.119.2-1.911c772.el7_8.noarch` (latest) and doesn't include `kubernetes_file_t `(introduced in v2.144 and later). Although this type is used (required) to create rke_kubereader_t in rancher.te-  the type rke_kubereader_t is then not installable/available. As a result, the container k8s_copy-certs_pushprox-kube-etcd-client (Monitoring chart) then falls back to container_t (with no sufficient permission to read /etc/kubernetes), and fails to execute.

**Fix:**

- /etc/kubernetes keeps rke_etc_t type
- rke_kubereader_t is adapted to be authorized to access rke_etc_t type
