### PR TITLE
Add file watch permission from rke_logreader_t to container_var_lib_t

### DIFF
--- a/policy/centos8/rancher.te
+++ b/policy/centos8/rancher.te
@@ -41,7 +41,7 @@ allow rke_logreader_t container_log_t:dir { open read search };
 allow rke_logreader_t container_log_t:lnk_file { getattr read };
 allow rke_logreader_t container_log_t:file { getattr open read watch };
 allow rke_logreader_t container_var_lib_t:dir search;
-allow rke_logreader_t container_var_lib_t:file { getattr open read };
+allow rke_logreader_t container_var_lib_t:file { getattr open read watch };
 allow rke_logreader_t container_var_lib_t:lnk_file { getattr read };
 allow rke_logreader_t syslogd_var_run_t:dir read;
 allow rke_logreader_t syslogd_var_run_t:file { getattr map open read };

--- a/policy/centos9/rancher.te
+++ b/policy/centos9/rancher.te
@@ -41,7 +41,7 @@ allow rke_logreader_t container_log_t:dir { open read search };
 allow rke_logreader_t container_log_t:lnk_file { getattr read };
 allow rke_logreader_t container_log_t:file { getattr open read watch };
 allow rke_logreader_t container_var_lib_t:dir search;
-allow rke_logreader_t container_var_lib_t:file { getattr open read };
+allow rke_logreader_t container_var_lib_t:file { getattr open read watch };
 allow rke_logreader_t container_var_lib_t:lnk_file { getattr read };
 allow rke_logreader_t syslogd_var_run_t:dir read;
 allow rke_logreader_t syslogd_var_run_t:file { getattr map open read };


### PR DESCRIPTION
This PR adds `watch` permission from `rke_logreader_t` to `container_var_lib_t` for `RHEL8` and `RHEL9` policies. 

Error related when installing [Logging V2](https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/selinux-rpm/about-rancher-selinux#configuring-the-logging-application-to-work-with-selinux) chart.
```
type=AVC msg=audit(1702641282.872:7238): avc:  denied  { watch } for  pid=129145 comm="flb-pipeline" path="/var/lib/docker/containers/27dc08805355a7bc7acbdbbb49e9de652402eae0716bc5344a46c093cd9d74ea/27dc08805355a7bc7acbdbbb49e9de652402eae0716bc5344a46c093cd9d74ea-json.log" dev="xvda4" ino=42055865 scontext=system_u:system_r:rke_logreader_t:s0:c500,c822 tcontext=system_u:object_r:container_var_lib_t:s0 tclass=file permissive=1
```

New policy tested against RHEL9 by installing Logging V2 (with selinux.enabled true) works as expected.

```
# sesearch -s rke_logreader_t -t container_var_lib_t -c file -p watch -A
allow rke_logreader_t container_var_lib_t:file { getattr open read watch };
```