### PR TITLE
build: Fixes AWS upload issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
         PRODUCTION_AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
         PRODUCTION_AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
         PRODUCTION_AWS_S3_BUCKET: ${{ secrets.PRODUCTION_AWS_S3_BUCKET }}
+        AWS_EC2_METADATA_DISABLED: true
 
     - run: make upload-gh
       env:


### PR DESCRIPTION
The AWS upload was failing with:

```
botocore.awsrequest.AWSRequest object at 0x7fddb0527e90> 38
make[1]: *** [Makefile:74: centos7-upload] Error 255
```

https://github.com/rancher/rancher-selinux/actions/runs/7791462916/job/21247603863