### PR TITLE
[Centos9] Add support for prometheus node-exporter container

### DIFF
--- a/policy/centos9/rancher.te
+++ b/policy/centos9/rancher.te
@@ -103,3 +103,51 @@ manage_files_pattern(rke_network_t, var_run_t, var_run_t)
 allow rke_network_t kernel_t:system module_request;
 allow rke_network_t kernel_t:unix_dgram_socket sendto;
 allow rke_network_t self:netlink_route_socket nlmsg_write;
+
+############################################################################
+# type prom_node_exporter_t   				 	           #
+# target: prometheus-node-exporter container for Rancher monitoring chart  #
+############################################################################
+require {
+	type container_runtime_t;
+	type prom_node_exporter_t;
+	class file { getattr open read };
+	class dir { getattr open read search };
+	class lnk_file { getattr read };
+	class process { fork noatsecure rlimitinh siginh sigkill signal transition };
+	class key { create search setattr view };
+	class tcp_socket { accept bind create getattr listen read setopt write };
+	class netlink_route_socket { bind create getattr getopt nlmsg_read read write };
+	class fd use;
+	class fifo_file write;
+}
+type prom_node_exporter_t;
+container_domain_template(prom_node_exporter_t, container)
+virt_sandbox_domain(prom_node_exporter_t)
+allow container_runtime_t prom_node_exporter_t:dir { open read search };
+allow container_runtime_t prom_node_exporter_t:file { getattr open read };
+allow container_runtime_t prom_node_exporter_t:key { create search setattr view };
+allow container_runtime_t prom_node_exporter_t:lnk_file { getattr read };
+allow container_runtime_t prom_node_exporter_t:process { noatsecure rlimitinh siginh sigkill signal transition };
+allow prom_node_exporter_t container_runtime_t:fd use;
+allow prom_node_exporter_t container_runtime_t:fifo_file write;
+allow prom_node_exporter_t self:dir { getattr search };
+allow prom_node_exporter_t self:file { open read };
+allow prom_node_exporter_t self:lnk_file read;
+allow prom_node_exporter_t self:netlink_route_socket { bind create getattr getopt nlmsg_read read write };
+allow prom_node_exporter_t self:process fork;
+allow prom_node_exporter_t self:tcp_socket { accept bind create getattr listen read setopt write };
+container_runtime_typebounds(prom_node_exporter_t)
+corenet_tcp_bind_generic_node(prom_node_exporter_t)
+corenet_tcp_bind_generic_port(prom_node_exporter_t)
+dev_list_sysfs(prom_node_exporter_t)
+dev_read_sysfs(prom_node_exporter_t)
+files_read_etc_symlinks(prom_node_exporter_t)
+init_read_state(prom_node_exporter_t)
+kernel_read_network_state(prom_node_exporter_t)
+kernel_read_network_state_symlinks(prom_node_exporter_t)
+kernel_read_proc_files(prom_node_exporter_t)
+kernel_read_proc_symlinks(prom_node_exporter_t)
+kernel_read_software_raid_state(prom_node_exporter_t)
+libs_read_lib_files(prom_node_exporter_t)
+selinux_read_security_files(prom_node_exporter_t)


### PR DESCRIPTION
**Targeted Env:**  Centos9
**Context:** The [Monitoring chart](https://ranchermanager.docs.rancher.com/integrations-in-rancher/monitoring-and-alerting) in Rancher can be used with SELinux enabled, however with the container-selinux policy installed (comes with k3s-selinux and rancher-selinux), the `node-exporter` container inherits `container_t`, which is not allowed to run several tasks. This makes the Monitoring app to stop running.

**Changes:** This PR introduces the addition of a new type `prom_node_exporter_t` along with the required rules to allow node-exporter to run with the least permissions.

Example of AVC denials that come along the assignment of `prom_node_exporter_t` to the `node-exporter` [container](https://github.com/rancher/charts/blob/6bb1a451af9bf34b3e7dd5765f575767e5a8b385/charts/rancher-monitoring/105.1.1%2Bup61.3.2/charts/prometheus-node-exporter/values.yaml#L7), and that are addressed in this PR.

<details open>
  <summary>AVCs</summary>

```
1. avc:  denied  { read } for  pid=243339 comm="k3s-server" scontext=system_u:system_r:container_runtime_t:s0 tcontext=system_u:system_r:prom_node_exporter_t:s0:c339,c717 tclass=file permissive=1
2. avc:  denied  { open } for  pid=243339 comm="k3s-server" path="/proc/1249142/limits" dev="proc" ino=29581995 scontext=system_u:system_r:container_runtime_t:s0 tcontext=system_u:system_r:prom_node_exporter_t:s0:c339,c717 tclass=file permissive=1
3. avc:  denied  { getattr } for  pid=243339 comm="k3s-server" path="/proc/1249142/limits" dev="proc" ino=29581995 scontext=system_u:system_r:container_runtime_t:s0 tcontext=system_u:system_r:prom_node_exporter_t:s0:c339,c717 tclass=file permissive=1
4. avc:  denied  { read } for  pid=1249174 comm="node_exporter" path="socket:[29581173]" dev="sockfs" ino=29581173 scontext=system_u:system_r:prom_node_exporter_t:s0:c272,c355 tcontext=system_u:system_r:prom_node_exporter_t:s0:c272,c355 tclass=tcp_socket permissive=1
5. avc:  denied  { read } for  pid=1249174 comm="node_exporter" name="stat" dev="proc" ino=29581175 scontext=system_u:system_r:prom_node_exporter_t:s0:c272,c355 tcontext=system_u:system_r:prom_node_exporter_t:s0:c272,c355 tclass=file permissive=1
6. avc:  denied  { open } for  pid=1249174 comm="node_exporter" path="/proc/1249174/stat" dev="proc" ino=29581175 scontext=system_u:system_r:prom_node_exporter_t:s0:c272,c355 tcontext=system_u:system_r:prom_node_exporter_t:s0:c272,c355 tclass=file permissive=1
7. avc:  denied  { read } for  pid=1249174 comm="node_exporter" name="net" dev="proc" ino=4026531845 scontext=system_u:system_r:prom_node_exporter_t:s0:c272,c355 tcontext=system_u:object_r:proc_net_t:s0 tclass=lnk_file permissive=1
8. avc:  denied  { read } for  pid=1249174 comm="node_exporter" name="self" dev="proc" ino=4026531842 scontext=system_u:system_r:prom_node_exporter_t:s0:c272,c355 tcontext=system_u:object_r:proc_t:s0 tclass=lnk_file permissive=1
9. avc:  denied  { read } for  pid=1249174 comm="node_exporter" name="clocksource" dev="sysfs" ino=7504 scontext=system_u:system_r:prom_node_exporter_t:s0:c272,c355 tcontext=system_u:object_r:sysfs_t:s0 tclass=dir permissive=1
10. avc:  denied  { read } for  pid=1249174 comm="node_exporter" name="netstat" dev="proc" ino=4026532056 scontext=system_u:system_r:prom_node_exporter_t:s0:c272,c355 tcontext=system_u:object_r:proc_net_t:s0 tclass=file permissive=1
11. avc:  denied  { open } for  pid=1249174 comm="node_exporter" path="/host/proc/1249174/net/netstat" dev="proc" ino=4026532056 scontext=system_u:system_r:prom_node_exporter_t:s0:c272,c355 tcontext=system_u:object_r:proc_net_t:s0 tclass=file permissive=1
12. avc:  denied  { getattr } for  pid=1249174 comm="node_exporter" path="/host/sys/fs/xfs/stats/stats" dev="sysfs" ino=19937 scontext=system_u:system_r:prom_node_exporter_t:s0:c272,c355 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=1
13. avc:  denied  { read } for  pid=1249174 comm="node_exporter" name="stats" dev="sysfs" ino=20003 scontext=system_u:system_r:prom_node_exporter_t:s0:c272,c355 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=1
14. avc:  denied  { open } for  pid=1249174 comm="node_exporter" path="/host/sys/fs/xfs/vda1/stats/stats" dev="sysfs" ino=20003 scontext=system_u:system_r:prom_node_exporter_t:s0:c272,c355 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=1
```

</details>
