### PR TITLE
E2E for Rancher Monitoring and Logging

### DIFF
--- a/hack/e2e/centos8.yaml
+++ b/hack/e2e/centos8.yaml
@@ -30,4 +30,4 @@ provision:
   script: |
     #!/bin/sh
 
-    yum in -y git container-selinux
+    yum in -y git jq container-selinux setools

--- a/hack/e2e/centos9.yaml
+++ b/hack/e2e/centos9.yaml
@@ -24,4 +24,4 @@ provision:
   script: |
     #!/bin/sh
 
-    yum in -y git container-selinux
+    yum in -y git container-selinux setools

--- a/hack/e2e/centos9.yaml
+++ b/hack/e2e/centos9.yaml
@@ -24,4 +24,4 @@ provision:
   script: |
     #!/bin/sh
 
-    yum in -y git container-selinux setools
+    yum in -y git jq container-selinux setools

--- a/hack/e2e/setup-vm.sh
+++ b/hack/e2e/setup-vm.sh
@@ -20,9 +20,15 @@ function installDependencies(){
 
     local KUBECTL_VERSION
     KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+    ARCH=$(uname -p)
+    if [[ "${ARCH}" == "aarch64" ]]; then
+    ARCH="arm64"
+    fi
 
-    echo "> Installing kubectl ${KUBECTL_VERSION}"
-    curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+    echo "> Installing kubectl ${KUBECTL_VERSION} for ${ARCH}"
+    curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+    curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl.sha256"
+    echo "$(<kubectl.sha256)  kubectl" | sha256sum -c -
     install -o root -g root -m 0755 kubectl /usr/bin/kubectl
     kubectl version --client=true
 }

--- a/hack/e2e/setup-vm.sh
+++ b/hack/e2e/setup-vm.sh
@@ -24,6 +24,8 @@ function installDependencies(){
     ARCH=$(uname -p)
     if [[ "${ARCH}" == "aarch64" ]]; then
     ARCH="arm64"
+    elif [[ "${ARCH}" == "x86_64" ]]; then
+    ARCH="amd64"
     fi
 
     echo "> Installing kubectl ${KUBECTL_VERSION} for ${ARCH}"
@@ -162,7 +164,7 @@ function e2eRancherMonitoring(){
     CHART_POD=$(kubectl get pods -n ${CHART_POD_NAMESPACE} -o custom-columns=NAME:.metadata.name | grep ${CHART_CONTAINER})
 
     echo "> Verify the presence of ${CHART_CONTAINER_EXPECTED_SLTYPE}"
-    if [[ "$(seinfo -t ${CHART_CONTAINER_EXPECTED_SLTYPE})" == "${CHART_CONTAINER_EXPECTED_SLTYPE}" ]]; then
+    if [[ "$(seinfo -t ${CHART_CONTAINER_EXPECTED_SLTYPE} | grep -o ${CHART_CONTAINER_EXPECTED_SLTYPE})" == "${CHART_CONTAINER_EXPECTED_SLTYPE}" ]]; then
         echo "SELinux type is present: ${CHART_CONTAINER_EXPECTED_SLTYPE}"
     else
         echo "SELinux type is not present: ${CHART_CONTAINER_EXPECTED_SLTYPE}"
@@ -177,7 +179,7 @@ function e2eRancherMonitoring(){
     fi
 
     echo ">Look for any AVCs related to ${CHART_CONTAINER_RUNNING_SLTYPE}"
-    if ausearch -m AVC,USER_AVC | grep -q ${CHART_CONTAINER_RUNNING_SLTYPE}; then
+    if ausearch -m AVC,USER_AVC | grep -q ${CHART_CONTAINER_RUNNING_SLTYPE} > /dev/null; then
         echo "AVCs found for ${CHART_CONTAINER_RUNNING_SLTYPE}"
         ausearch -m AVC,USER_AVC | grep ${CHART_CONTAINER_RUNNING_SLTYPE}
         exit 1
@@ -216,7 +218,7 @@ function e2eRancherLogging(){
     CHART_POD=$(kubectl get pods -n ${CHART_POD_NAMESPACE} -o custom-columns=NAME:.metadata.name | grep "${CHART_CONTAINER}")
 
     echo "> Verify the presence of ${CHART_CONTAINER_EXPECTED_SLTYPE}"
-    if [[ "$(seinfo -t ${CHART_CONTAINER_EXPECTED_SLTYPE})" == "${CHART_CONTAINER_EXPECTED_SLTYPE}" ]]; then
+    if [[ "$(seinfo -t ${CHART_CONTAINER_EXPECTED_SLTYPE} | grep -o ${CHART_CONTAINER_EXPECTED_SLTYPE})" == "${CHART_CONTAINER_EXPECTED_SLTYPE}" ]]; then
         echo "SELinux type is present: ${CHART_CONTAINER_EXPECTED_SLTYPE}"
     else
         echo "SELinux type is not present: ${CHART_CONTAINER_EXPECTED_SLTYPE}"
@@ -231,7 +233,7 @@ function e2eRancherLogging(){
     fi
 
     echo ">Look for any AVCs related to ${CHART_CONTAINER_RUNNING_SLTYPE}"
-    if ausearch -m AVC,USER_AVC | grep -q ${CHART_CONTAINER_RUNNING_SLTYPE}; then
+    if ausearch -m AVC,USER_AVC | grep -q ${CHART_CONTAINER_RUNNING_SLTYPE} > /dev/null; then
         echo "AVCs found for ${CHART_CONTAINER_RUNNING_SLTYPE}"
         ausearch -m AVC,USER_AVC | grep ${CHART_CONTAINER_RUNNING_SLTYPE}
         exit 1

--- a/policy/centos8/rancher.te
+++ b/policy/centos8/rancher.te
@@ -103,3 +103,20 @@ manage_files_pattern(rke_network_t, var_run_t, var_run_t)
 allow rke_network_t kernel_t:system module_request;
 allow rke_network_t kernel_t:unix_dgram_socket sendto;
 allow rke_network_t self:netlink_route_socket nlmsg_write;
+
+############################################################################
+# type prom_node_exporter_t                                                #
+# target: prometheus-node-exporter container for Rancher monitoring chart  #
+############################################################################
+gen_require(`
+        type container_runtime_t;
+	type security_t;
+        class tcp_socket listen;
+')
+container_domain_template(prom_node_exporter, container)
+virt_sandbox_domain(prom_node_exporter_t)
+corenet_tcp_bind_generic_node(prom_node_exporter_t)
+corenet_tcp_bind_generic_port(prom_node_exporter_t)
+init_read_state(prom_node_exporter_t)
+allow prom_node_exporter_t self:tcp_socket listen;
+allow prom_node_exporter_t security_t:file { getattr open read };

--- a/policy/centos8/rancher.te
+++ b/policy/centos8/rancher.te
@@ -47,6 +47,7 @@ allow rke_logreader_t syslogd_var_run_t:dir read;
 allow rke_logreader_t syslogd_var_run_t:file { getattr map open read };
 allow rke_logreader_t var_log_t:dir read;
 allow rke_logreader_t var_log_t:file { getattr map open read watch };
+allow rke_logreader_t self:tcp_socket listen;
 
 ########################
 # type rke_container_t #

--- a/policy/centos9/rancher.te
+++ b/policy/centos9/rancher.te
@@ -47,7 +47,7 @@ allow rke_logreader_t syslogd_var_run_t:dir read;
 allow rke_logreader_t syslogd_var_run_t:file { getattr map open read };
 allow rke_logreader_t var_log_t:dir read;
 allow rke_logreader_t var_log_t:file { getattr map open read watch };
-allow rke_logreader_t self:tcp_socket { accept listen };
+allow rke_logreader_t self:tcp_socket listen;
 
 ########################
 # type rke_container_t #

--- a/policy/centos9/rancher.te
+++ b/policy/centos9/rancher.te
@@ -47,6 +47,7 @@ allow rke_logreader_t syslogd_var_run_t:dir read;
 allow rke_logreader_t syslogd_var_run_t:file { getattr map open read };
 allow rke_logreader_t var_log_t:dir read;
 allow rke_logreader_t var_log_t:file { getattr map open read watch };
+allow rke_logreader_t self:tcp_socket { accept listen };
 
 ########################
 # type rke_container_t #


### PR DESCRIPTION
**Description:**

1. Add support to ARM64 and deps ( jq and seinfo)
2. Append Centos8 Policy with `prom_node_exporter_t`
3. Fix Centos8 Policy for `rke_logreader_t` (back port #62)
4. Adds SELinux e2e testing for the Rancher Monitoring and Logging chart. 

Here is a breakdown of the functions:

- **installRancherMonitoring**
  - Installs Rancher Monitoring chart. Note: Rancher Monitoring relies on a new `prom_node_exporter_t` type that will be released later on. It doesn't yet include the verification of the default assignment of [rke_kubereader_t ](https://github.com/rancher/charts/blob/d8681a96f53bef27ed8287f122e276135268e2ad/charts/rancher-monitoring/106.0.0%2Bup61.3.2/values.yaml#L104)meant for `pushprox-kube-etcd-client` container.
  - Patches node-exporter pod with the new `prom_node_exporter_t` type
- **installRancherLogging**
  - install Rancher Logging chart by setting the selinux.enabled to true (which sets the rke_logreader_t to the fluentbit container)
  - Verify that daemonset is created and ready
- **e2eRancherMonitoring**
   - Test the presence of `prom_node_exporter_` type
   - Test that fluent bit container is assigned to `prom_node_exporter_`
   - Verify if any AVCs are generated for `prom_node_exporter_`
- **e2eRancherLogging**
   - Test the presence of `rke_logreader_t` type
   - Test that fluent bit container is assigned to `rke_logreader_t`
   - Verify if any AVCs are generated for `rke_logreader_t`
