### PR TITLE
Distro update support and consolidate gen_require

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,14 @@ The following Rancher compnents are covered by the policy:
 | RKE1                       | [flannel]                                                                | `rke_network_t`        |
 | RKE1                       | [rke] `etcd`, `rke-etcd-backup`, `kube-{apiserver,controller,scheduler}` | `rke_container_t`      |
 
-
 ## Support Matrix
 
-| Operating System | Version | Supported          | Policy     | E2E                   |
-| :--------------- | :------ | :----------------- | :--------- | :-------------------- |
-| RHEL/Rocky       | 8       | :white_check_mark: | [centos8]  | :white_check_mark:    |
-| RHEL/Rocky       | 9       | :white_check_mark: | [centos9]  | :white_check_mark:    |
-| Fedora           | 41      | :white_check_mark: | [fedora41] | :white_check_mark:    |
-| openSUSE MicroOS | Stable  | :white_check_mark: | [microos]  | :construction:        |
-| openSUSE Leap    | N/A     | :construction:     | N/A        | :construction:        |
-| SUSE Liberty     | N/A     | :construction:     | N/A        | :construction:        |
-| openSUSE SLE     | N/A     | :construction:     | N/A        | :construction:        |
-| Oracle Linux     | N/A     | :construction:     | N/A        | :construction:        |
+| Operating System      | Version | Supported          | Policy     | E2E                   |
+| :-------------------- | :------ | :----------------- | :--------- | :-------------------- |
+| RHEL/CentOS/Rocky     | 8       | :white_check_mark: | [centos8]  | :white_check_mark:    |
+| RHEL/CentOS/Rocky     | 9       | :white_check_mark: | [centos9]  | :white_check_mark:    |
+| Fedora                | 41      | :white_check_mark: | [fedora41] | :white_check_mark:    |
+| SUSE SLE/Micro        | Stable  | :white_check_mark: | [microos]  | :construction:        |
 
 ## Versioning/Tagging
 

--- a/policy/centos8/rancher-selinux.spec
+++ b/policy/centos8/rancher-selinux.spec
@@ -1,7 +1,7 @@
 # vim: sw=4:ts=4:et
 
-%define selinux_policyver 3.13.1-252
-%define container_policyver 2.144.0-1
+%define selinux_policyver 3.14.3-139
+%define container_policyver 2.229.0-2
 
 %define relabel_files() \
 mkdir -p /var/lib/rancher/rke /etc/kubernetes /opt/rke; \

--- a/policy/centos8/rancher.te
+++ b/policy/centos8/rancher.te
@@ -1,20 +1,24 @@
 policy_module(rancher, 1.0.0)
 
 gen_require(`
-    type container_runtime_t, unconfined_service_t;
-    type container_file_t;
+    type container_runtime_t, unconfined_service_t, container_file_t;
+    type kubernetes_file_t, container_log_t, syslogd_var_run_t;
+    type var_log_t, container_var_run_t, container_var_lib_t;
+    type iptables_var_run_t, var_run_t, kernel_t, rke_opt_t, security_t;
+    class dir { open read search };
+    class file { getaddr getattr map open read watch relabelfrom relabelto };
+    class lnk_file { getattr read };
+    class tcp_socket { accept listen };
+    class netlink_route_socket { nlmsg_write };
+    class system { module_request };
+    class unix_dgram_socket { sendto };
 ')
 
-########################
-# type rke_kubereader_t #
-########################
-gen_require(`
-        type container_runtime_t, unconfined_service_t;
-        type kubernetes_file_t;
-        class dir { open read search };
-        class file { getaddr open read };
-        class lnk_file { getattr read };
-')
+############################################################
+# type: rke_kubereader_t                                   #
+# target: pushprox container for Rancher monitoring chart  #
+############################################################
+
 container_domain_template(rke_kubereader, container)
 virt_sandbox_domain(rke_kubereader_t)
 corenet_unconfined(rke_kubereader_t)
@@ -22,18 +26,11 @@ allow rke_kubereader_t kubernetes_file_t:dir { open read search };
 allow rke_kubereader_t kubernetes_file_t:file { getattr open read };
 allow rke_kubereader_t kubernetes_file_t:lnk_file { getattr read };
 
-########################
-# type rke_logreader_t #
-########################
-gen_require(`
-        type container_runtime_t, unconfined_service_t;
-        type container_log_t;
-        type syslogd_var_run_t;
-        type var_log_t;
-        class dir { read search };
-        class file { getattr map open read watch };
-        class lnk_file { getattr read };
-')
+############################################################
+# type: rke_logreader_t                                    #
+# target: fluentbit container for Rancher logging chart    #
+############################################################
+
 container_domain_template(rke_logreader, container)
 virt_sandbox_domain(rke_logreader_t)
 corenet_unconfined(rke_logreader_t)
@@ -49,17 +46,11 @@ allow rke_logreader_t var_log_t:dir read;
 allow rke_logreader_t var_log_t:file { getattr map open read watch };
 allow rke_logreader_t self:tcp_socket listen;
 
-########################
-# type rke_container_t #
-########################
-gen_require(`
-        type container_runtime_t, unconfined_service_t;
-        type container_log_t;
-        type kubernetes_file_t;
-        type container_var_run_t;
-        class dir { read search };
-        class file { open read };
-')
+############################################################################
+# type: rke_container_t                                                    #
+# target: RKE1 services                                                    #
+############################################################################
+
 type rke_opt_t;
 files_type(rke_opt_t)
 container_domain_template(rke_container, container)
@@ -85,15 +76,11 @@ allow rke_container_t container_var_lib_t:file { relabelfrom relabelto };
 allow rke_container_t rke_opt_t:dir { relabelfrom relabelto };
 allow rke_container_t rke_opt_t:file { relabelfrom relabelto };
 
-########################
-# type rke_network_t   #
-########################
-gen_require(`
-        type container_runtime_t, unconfined_service_t;
-        type iptables_var_run_t;
-        type var_run_t;
-        type kernel_t;
-')
+############################################################################
+# type: rke_network_t                                                      #
+# target: flannel container for RKE1                                       #
+############################################################################
+
 container_domain_template(rke_network, container)
 virt_sandbox_domain(rke_network_t)
 corenet_unconfined(rke_network_t)
@@ -109,11 +96,7 @@ allow rke_network_t self:netlink_route_socket nlmsg_write;
 # type prom_node_exporter_t                                                #
 # target: prometheus-node-exporter container for Rancher monitoring chart  #
 ############################################################################
-gen_require(`
-        type container_runtime_t;
-	type security_t;
-        class tcp_socket listen;
-')
+
 container_domain_template(prom_node_exporter, container)
 virt_sandbox_domain(prom_node_exporter_t)
 corenet_tcp_bind_generic_node(prom_node_exporter_t)

--- a/policy/centos9/rancher-selinux.spec
+++ b/policy/centos9/rancher-selinux.spec
@@ -1,7 +1,7 @@
 # vim: sw=4:ts=4:et
 
-%define selinux_policyver 3.13.1-252
-%define container_policyver 2.144.0-1
+%define selinux_policyver 38.1.45-3
+%define container_policyver 2.232.1-1
 
 %define relabel_files() \
 mkdir -p /var/lib/rancher/rke /etc/kubernetes /opt/rke; \

--- a/policy/centos9/rancher.te
+++ b/policy/centos9/rancher.te
@@ -1,20 +1,24 @@
 policy_module(rancher, 1.0.0)
 
 gen_require(`
-    type container_runtime_t, unconfined_service_t;
-    type container_file_t;
+    type container_runtime_t, unconfined_service_t, container_file_t;
+    type kubernetes_file_t, container_log_t, syslogd_var_run_t;
+    type var_log_t, container_var_run_t, container_var_lib_t;
+    type iptables_var_run_t, var_run_t, kernel_t, rke_opt_t;
+    class dir { open read search };
+    class file { getaddr getattr map open read watch relabelfrom relabelto };
+    class lnk_file { getattr read };
+    class tcp_socket { accept listen };
+    class netlink_route_socket { nlmsg_write };
+    class system { module_request };
+    class unix_dgram_socket { sendto };
 ')
 
-########################
-# type rke_kubereader_t #
-########################
-gen_require(`
-        type container_runtime_t, unconfined_service_t;
-        type kubernetes_file_t;
-        class dir { open read search };
-        class file { getaddr open read };
-        class lnk_file { getattr read };
-')
+############################################################
+# type: rke_kubereader_t                                   #
+# target: pushprox container for Rancher monitoring chart  #
+############################################################
+
 container_domain_template(rke_kubereader, container)
 virt_sandbox_domain(rke_kubereader_t)
 corenet_unconfined(rke_kubereader_t)
@@ -22,18 +26,11 @@ allow rke_kubereader_t kubernetes_file_t:dir { open read search };
 allow rke_kubereader_t kubernetes_file_t:file { getattr open read };
 allow rke_kubereader_t kubernetes_file_t:lnk_file { getattr read };
 
-########################
-# type rke_logreader_t #
-########################
-gen_require(`
-        type container_runtime_t, unconfined_service_t;
-        type container_log_t;
-        type syslogd_var_run_t;
-        type var_log_t;
-        class dir { read search };
-        class file { getattr map open read watch };
-        class lnk_file { getattr read };
-')
+############################################################
+# type: rke_logreader_t                                    #
+# target: fluentbit container for Rancher logging chart    #
+############################################################
+
 container_domain_template(rke_logreader, container)
 virt_sandbox_domain(rke_logreader_t)
 corenet_unconfined(rke_logreader_t)
@@ -49,17 +46,11 @@ allow rke_logreader_t var_log_t:dir read;
 allow rke_logreader_t var_log_t:file { getattr map open read watch };
 allow rke_logreader_t self:tcp_socket listen;
 
-########################
-# type rke_container_t #
-########################
-gen_require(`
-        type container_runtime_t, unconfined_service_t;
-        type container_log_t;
-        type kubernetes_file_t;
-        type container_var_run_t;
-        class dir { read search };
-        class file { open read };
-')
+############################################################################
+# type: rke_container_t                                                    #
+# target: RKE1 services                                                    #
+############################################################################
+
 type rke_opt_t;
 files_type(rke_opt_t)
 container_domain_template(rke_container, container)
@@ -85,15 +76,11 @@ allow rke_container_t container_var_lib_t:file { relabelfrom relabelto };
 allow rke_container_t rke_opt_t:dir { relabelfrom relabelto };
 allow rke_container_t rke_opt_t:file { relabelfrom relabelto };
 
-########################
-# type rke_network_t   #
-########################
-gen_require(`
-        type container_runtime_t, unconfined_service_t;
-        type iptables_var_run_t;
-        type var_run_t;
-        type kernel_t;
-')
+############################################################################
+# type: rke_network_t                                                      #
+# target: flannel container for RKE1                                       #
+############################################################################
+
 container_domain_template(rke_network, container)
 virt_sandbox_domain(rke_network_t)
 corenet_unconfined(rke_network_t)
@@ -106,13 +93,10 @@ allow rke_network_t kernel_t:unix_dgram_socket sendto;
 allow rke_network_t self:netlink_route_socket nlmsg_write;
 
 ############################################################################
-# type prom_node_exporter_t                                                #
+# type: prom_node_exporter_t                                               #
 # target: prometheus-node-exporter container for Rancher monitoring chart  #
 ############################################################################
-gen_require(`
-        type container_runtime_t;
-        class tcp_socket listen;
-')
+
 container_domain_template(prom_node_exporter, container)
 virt_sandbox_domain(prom_node_exporter_t)
 corenet_tcp_bind_generic_node(prom_node_exporter_t)

--- a/policy/fedora41/rancher.te
+++ b/policy/fedora41/rancher.te
@@ -10,9 +10,10 @@ gen_require(`
     class tcp_socket { listen };
 ')
 
-#########################
-# type rke_kubereader_t #
-#########################
+############################################################
+# type: rke_kubereader_t                                   #
+# target: pushprox container for Rancher monitoring chart  #
+############################################################
 
 container_domain_template(rke_kubereader, container)
 virt_sandbox_domain(rke_kubereader_t)
@@ -21,9 +22,10 @@ allow rke_kubereader_t kubernetes_file_t:dir { open read search };
 allow rke_kubereader_t kubernetes_file_t:file { getattr open read };
 allow rke_kubereader_t kubernetes_file_t:lnk_file { getattr read };
 
-########################
-# type rke_logreader_t #
-########################
+############################################################
+# type: rke_logreader_t                                    #
+# target: fluentbit container for Rancher logging chart    #
+############################################################
 
 container_domain_template(rke_logreader, container)
 virt_sandbox_domain(rke_logreader_t)
@@ -40,9 +42,10 @@ allow rke_logreader_t var_log_t:dir read;
 allow rke_logreader_t var_log_t:file { getattr map open read };
 allow rke_logreader_t self:tcp_socket listen;
 
-########################
-# type rke_container_t #
-########################
+############################################################################
+# type: rke_container_t                                                    #
+# target: RKE1 services                                                    #
+############################################################################
 
 type rke_opt_t;
 files_type(rke_opt_t)
@@ -69,9 +72,10 @@ allow rke_container_t container_var_lib_t:file { relabelfrom relabelto };
 allow rke_container_t rke_opt_t:dir { relabelfrom relabelto };
 allow rke_container_t rke_opt_t:file { relabelfrom relabelto };
 
-########################
-# type rke_network_t   #
-########################
+############################################################################
+# type: rke_network_t                                                      #
+# target: flannel container for RKE1                                       #
+############################################################################
 
 container_domain_template(rke_network, container)
 virt_sandbox_domain(rke_network_t)

--- a/policy/microos/rancher-selinux.spec
+++ b/policy/microos/rancher-selinux.spec
@@ -1,7 +1,7 @@
 # vim: sw=4:ts=4:et
 
-%define selinux_policyver 20210716-3.1
-%define container_policyver 2.164.2-1.1
+%define selinux_policyver 20250507-1.1
+%define container_policyver 2.237.0-1.1
 
 %define relabel_files() \
 mkdir -p /var/lib/rancher/rke /etc/kubernetes /opt/rke; \

--- a/policy/microos/rancher.te
+++ b/policy/microos/rancher.te
@@ -1,20 +1,24 @@
 policy_module(rancher, 1.0.0)
 
 gen_require(`
-    type container_runtime_t, unconfined_service_t;
-    type container_file_t;
+    type container_runtime_t, unconfined_service_t, container_file_t;
+    type kubernetes_file_t, container_log_t, syslogd_var_run_t;
+    type var_log_t, container_var_run_t, container_var_lib_t;
+    type iptables_var_run_t, var_run_t, kernel_t, rke_opt_t;
+    class dir { open read search };
+    class file { getaddr getattr map open read watch relabelfrom relabelto };
+    class lnk_file { getattr read };
+    class tcp_socket { accept listen };
+    class netlink_route_socket { nlmsg_write };
+    class system { module_request };
+    class unix_dgram_socket { sendto };
 ')
 
-########################
-# type rke_kubereader_t #
-########################
-gen_require(`
-        type container_runtime_t, unconfined_service_t;
-        type kubernetes_file_t;
-        class dir { open read search };
-        class file { getaddr open read };
-        class lnk_file { getattr read };
-')
+############################################################
+# type: rke_kubereader_t                                   #
+# target: pushprox container for Rancher monitoring chart  #
+############################################################
+
 container_domain_template(rke_kubereader, container)
 virt_sandbox_domain(rke_kubereader_t)
 corenet_unconfined(rke_kubereader_t)
@@ -22,18 +26,11 @@ allow rke_kubereader_t kubernetes_file_t:dir { open read search };
 allow rke_kubereader_t kubernetes_file_t:file { getattr open read };
 allow rke_kubereader_t kubernetes_file_t:lnk_file { getattr read };
 
-########################
-# type rke_logreader_t #
-########################
-gen_require(`
-        type container_runtime_t, unconfined_service_t;
-        type container_log_t;
-        type syslogd_var_run_t;
-        type var_log_t;
-        class dir { read search };
-        class file { open read };
-        class lnk_file { getattr read };
-')
+############################################################
+# type: rke_logreader_t                                    #
+# target: fluentbit container for Rancher logging chart    #
+############################################################
+
 container_domain_template(rke_logreader, container)
 virt_sandbox_domain(rke_logreader_t)
 corenet_unconfined(rke_logreader_t)
@@ -48,17 +45,11 @@ allow rke_logreader_t syslogd_var_run_t:file { getattr open read };
 allow rke_logreader_t var_log_t:dir read;
 allow rke_logreader_t var_log_t:file { getattr open read };
 
-########################
-# type rke_container_t #
-########################
-gen_require(`
-        type container_runtime_t, unconfined_service_t;
-        type container_log_t;
-        type kubernetes_file_t;
-        type container_var_run_t;
-        class dir { read search };
-        class file { open read };
-')
+############################################################################
+# type: rke_container_t                                                    #
+# target: RKE1 services                                                    #
+############################################################################
+
 type rke_opt_t;
 files_type(rke_opt_t)
 container_domain_template(rke_container, container)
@@ -84,15 +75,11 @@ allow rke_container_t container_var_lib_t:file { relabelfrom relabelto };
 allow rke_container_t rke_opt_t:dir { relabelfrom relabelto };
 allow rke_container_t rke_opt_t:file { relabelfrom relabelto };
 
-########################
-# type rke_network_t   #
-########################
-gen_require(`
-        type container_runtime_t, unconfined_service_t;
-        type iptables_var_run_t;
-        type var_run_t;
-        type kernel_t;
-')
+############################################################################
+# type: rke_network_t                                                      #
+# target: flannel container for RKE1                                       #
+############################################################################
+
 container_domain_template(rke_network, container)
 virt_sandbox_domain(rke_network_t)
 corenet_unconfined(rke_network_t)
@@ -108,10 +95,7 @@ allow rke_network_t self:netlink_route_socket nlmsg_write;
 # type prom_node_exporter_t                                                #
 # target: prometheus-node-exporter container for Rancher monitoring chart  #
 ############################################################################
-gen_require(`
-        type container_runtime_t;
-        class tcp_socket listen;
-')
+
 container_domain_template(prom_node_exporter, container)
 virt_sandbox_domain(prom_node_exporter_t)
 corenet_tcp_bind_generic_node(prom_node_exporter_t)


### PR DESCRIPTION
**Description:**

- Consolidate `gen_require` and improve comments for all rancher.te distro policies
- Set `container-selinux` and `selinux-policy` versions (based on latest available)

**Note:**

The `gen_require` are explicitly emphasizing the classes and types that are used in the policies's rules, even if most of them are already declared in the interfaces.