### PR TITLE
add vendor/packager details to rancher-selinux rpm

### DIFF
--- a/policy/centos8/rancher-selinux.spec
+++ b/policy/centos8/rancher-selinux.spec
@@ -11,6 +11,8 @@ Name:   rancher-selinux
 Version:	%{rancher_selinux_version}
 Release:	%{rancher_selinux_release}.el8
 Summary:	SELinux policy module for Rancher
+Vendor:     SUSE LLC
+Packager:   SUSE LLC <https://www.suse.com/>
 
 Group:	System Environment/Base
 License:	Apache-2.0

--- a/policy/centos9/rancher-selinux.spec
+++ b/policy/centos9/rancher-selinux.spec
@@ -11,6 +11,8 @@ Name:   rancher-selinux
 Version:	%{rancher_selinux_version}
 Release:	%{rancher_selinux_release}.el9
 Summary:	SELinux policy module for Rancher
+Vendor:     SUSE LLC
+Packager:   SUSE LLC <https://www.suse.com/>
 
 Group:	System Environment/Base
 License:	Apache-2.0

--- a/policy/fedora41/rancher-selinux.spec
+++ b/policy/fedora41/rancher-selinux.spec
@@ -11,6 +11,8 @@ Name:   rancher-selinux
 Version:	%{rancher_selinux_version}
 Release:	%{rancher_selinux_release}.fc41
 Summary:	SELinux policy module for Rancher
+Vendor:     SUSE LLC
+Packager:   SUSE LLC <https://www.suse.com/>
 
 Group:	System Environment/Base
 License:	Apache-2.0

--- a/policy/microos/rancher-selinux.spec
+++ b/policy/microos/rancher-selinux.spec
@@ -11,6 +11,8 @@ Name:   rancher-selinux
 Version:	%{rancher_selinux_version}
 Release:	%{rancher_selinux_release}.sle
 Summary:	SELinux policy module for Rancher
+Vendor:     SUSE LLC
+Packager:   SUSE LLC <https://www.suse.com/>
 
 Group:	System Environment/Base
 License:	Apache-2.0


### PR DESCRIPTION
Fixes: https://github.com/rancher/rancher-selinux/issues/96

Manual testing:
```

root@ip-17 centos9]# rpm -qi rancher-selinux | rg '^(Name|Version|Vendor|Packager|Distribution)'
Name        : rancher-selinux
Version     : 1.30
Packager    : SUSE LLC <https://www.suse.com/>
Vendor      : SUSE LLC
[root@ip-17 centos9]# 

```