### PR TITLE
renovate: add schedule to run renovate monthly

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,16 @@
       "matchPackageNames": ["fedora"],
       "matchDatasources": ["docker"],
       "allowedVersions": "<42.0.0"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "quay.io/centos/centos",
+        "fedora",
+        "opensuse/tumbleweed"
+      ],
+      "schedule": ["on the first day of the month"],
+      "automerge": false 
     }
   ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN yum install -y \
         rpm-build \
         rpm-sign
 
-FROM quay.io/centos/centos:stream9@sha256:e15ceb6e8744ccb658c6d8cb81cf2853398ca3a611f41f0b8e2fce655361190d AS centos9
+FROM quay.io/centos/centos:stream9@sha256:0bf070f10582acaa3c415280f769797025763c8a8e6509a5883592d0872a56d6 AS centos9
 RUN yum install -y \
         createrepo_c \
         epel-release \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN yum install -y \
         rpm-build \
         rpm-sign
 
-FROM fedora:41@sha256:c3643bda846169b342b400d4bbd1cb7022a7037e108b403a97305d1cb1644bcd AS fedora41
+FROM fedora:41@sha256:f1a3fab47bcb3c3ddf3135d5ee7ba8b7b25f2e809a47440936212a3a50957f3d AS fedora41
 RUN dnf install -y \
         createrepo_c \
         container-selinux \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN dnf install -y \
         rpm-build \
         rpm-sign
 
-FROM opensuse/tumbleweed:latest@sha256:fef63b8f471b4968309bbc9065a176202e30d67df56d3b8b9962a7cb8ea934d9 AS microos
+FROM opensuse/tumbleweed:latest@sha256:e6078e56685808dc36d5b31a13c80e4ecf1ebcae06476d8153d0d8be777f58ce AS microos
 RUN zypper install -y \
         container-selinux \
         selinux-policy-devel \


### PR DESCRIPTION
### Description:
#### Renovate configuration:
- Add a **schedule** ~~`before 3am on the first day of the month`~~ `on the first day of the month` for Docker image digest to be updated less frequently.
- Excerpt of the local run in dry mode (`LOG_LEVEL=debug renovate --platform=local --dry-run=full --repository-cache=reset`)

```
DEBUG: detectSemanticCommits() (repository=local)
DEBUG: semanticCommits: returning "disabled" from cache (repository=local)
DEBUG: processRepo() (repository=local)
DEBUG: Processing 2 branches: renovate/fedora-41, renovate/opensuse-tumbleweed-latest (repository=local)
DEBUG: 0 PRs are currently open (repository=local)
DEBUG: ConcurrentPRs count = 0 (repository=local)
DEBUG: 2 already existing branches found. (repository=local)
DEBUG: Branches count = 2 (repository=local)
DEBUG: Calculating PRs created so far in this hour currentHourStart=2025-12-09T09:00:00.000Z (repository=local)
DEBUG: 0 PRs have been created so far in this hour. (repository=local)
DEBUG: HourlyPRs count = 0 (repository=local)
DEBUG: syncBranchState() (repository=local, branch=renovate/fedora-41)
DEBUG: syncBranchState(): Branch cache not found, creating minimal branchState (repository=local, branch=renovate/fedora-41)
DEBUG: branchExists=true (repository)=local, branch=renovate/fedora-41)
DEBUG: dependencyDashboardCheck=undefined (repository=local, branch=renovate/fedora-41)
DEBUG: Check for closed PR because recreating closed PRs is disabled. (repository=local, branch=renovate/fedora-41)
DEBUG: prAlreadyExisted=false (repository=local, branch=renovate/fedora-41)
DEBUG: Open PR Count: 0, Existing Branch Count: 2, Hourly PR Count: 0 (repository=local, branch=renovate/fedora-41)
DEBUG: Checking if PR has been edited (repository=local, branch=renovate/fedora-41)
DEBUG: Checking schedule(schedule=on the first day of the month, tz=null, now=2025-12-09T09:51:51.317Z) (repository=local, branch=renovate/fedora-41)
DEBUG: Checking 1 schedule(s) (repository=local, branch=renovate/fedora-41)
DEBUG: Checking schedule "on the first day of the month" (repository=local, branch=renovate/fedora-41)
       "parsedSchedule": {"schedules": [{"D": [1]}], "exceptions": [], "error": -1}
DEBUG: Package not scheduled (repository=local, branch=renovate/fedora-41)
DEBUG: Skipping PR creation out of schedule (repository=local, branch=renovate/fedora-41)
DEBUG: syncBranchState() (repository=local, branch=renovate/opensuse-tumbleweed-latest)
DEBUG: syncBranchState(): Branch cache not found, creating minimal branchState (repository=local, branch=renovate/opensuse-tumbleweed-latest)
DEBUG: branchExists=true (repository=local, branch=renovate/opensuse-tumbleweed-latest)
DEBUG: dependencyDashboardCheck=undefined (repository=local, branch=renovate/opensuse-tumbleweed-latest)
DEBUG: Check for closed PR because recreating closed PRs is disabled. (repository=local, branch=renovate/opensuse-tumbleweed-latest)
DEBUG: prAlreadyExisted=false (repository=local, branch=renovate/opensuse-tumbleweed-latest)
DEBUG: Open PR Count: 0, Existing Branch Count: 2, Hourly PR Count: 0 (repository=local, branch=renovate/opensuse-tumbleweed-latest)
DEBUG: Checking if PR has been edited (repository=local, branch=renovate/opensuse-tumbleweed-latest)
DEBUG: Checking schedule(schedule=on the first day of the month, tz=null, now=2025-12-09T09:51:51.319Z) (repository=local, branch=renovate/opensuse-tumbleweed-latest)
DEBUG: Checking 1 schedule(s) (repository=local, branch=renovate/opensuse-tumbleweed-latest)
DEBUG: Checking schedule "on the first day of the month" (repository=local, branch=renovate/opensuse-tumbleweed-latest)
       "parsedSchedule": {"schedules": [{"D": [1]}], "exceptions": [], "error": -1}
DEBUG: Package not scheduled (repository=local, branch=renovate/opensuse-tumbleweed-latest)
DEBUG: Skipping PR creation out of schedule (repository=local, branch=renovate/opensuse-tumbleweed-latest)
DEBUG: Existing config file no longer exists (repository=local)
DEBUG: Got file list using git (repository=local)
DEBUG: Found .github/renovate.json config file (repository=local)
DEBUG: Repository config (repository=local)
       "fileName": ".github/renovate.json",
       "config": {
         "extends": ["github>rancher/renovate-config#release"],
         "baseBranchPatterns": ["main"],
         "prHourlyLimit": 2,
         "packageRules": [
           {
             "matchPackageNames": ["fedora"],
             "matchDatasources": ["docker"],
             "allowedVersions": "<42.0.0"
           },
           {
             "matchDatasources": ["docker"],
             "matchPackageNames": [
               "quay.io/centos/centos",
               "fedora",
               "opensuse/tumbleweed"
             ],
             "schedule": ["on the first day of the month"],
             "automerge": false
           }
         ]
       }
DEBUG: Config does not need migration (repository=local)
DEBUG: ensureDependencyDashboard() (repository=local)
 INFO: DRY-RUN: Would close Dependency Dashboard (repository=local)
       "title": "Dependency Dashboard"
DEBUG: checkReconfigureBranch() (repository=local)
DEBUG: Not attempting to reconfigure when running with local platform (repository=local)
 INFO: DRY-RUN: Would save repository cache. (repository=local)
DEBUG: Removing any stale branches (repository=local)
DEBUG: config.repoIsOnboarded=true (repository=local)
DEBUG: No renovate branches found (repository=local)
DEBUG: PackageFiles.clear() - Package files deleted (repository=local)
DEBUG: Branch summary (repository=local)
       "cacheModified": undefined,
       "baseBranches": [{"branchName": "", "sha": null}],
       "branches": [],
       "defaultBranch": "",
       "inactiveBranches": ["renovate/fedora-41", "renovate/opensuse-tumbleweed-latest"]
DEBUG: branches info extended (repository=local)
       "branchesInformation": [
         {
           "branchName": "renovate/fedora-41",
           "prNo": null,
           "prTitle": "Update fedora:41 Docker digest to f1a3fab",
           "result": "not-scheduled",
           "upgrades": [
             {
               "datasource": "docker",
               "depName": "fedora",
               "displayPending": "",
               "fixedVersion": "41",
               "currentVersion": "41",
               "currentValue": "41",
               "currentDigest": "sha256:c3643bda846169b342b400d4bbd1cb7022a7037e108b403a97305d1cb1644bcd",
               "newValue": "41",
               "newDigest": "sha256:f1a3fab47bcb3c3ddf3135d5ee7ba8b7b25f2e809a47440936212a3a50957f3d",
               "packageFile": "Dockerfile",
               "updateType": "digest",
               "packageName": "fedora"
             }
           ]
         },
         {
           "branchName": "renovate/opensuse-tumbleweed-latest",
           "prNo": null,
           "prTitle": "Update opensuse/tumbleweed:latest Docker digest to e6078e5",
           "result": "not-scheduled",
           "upgrades": [
             {
               "datasource": "docker",
               "depName": "opensuse/tumbleweed",
               "displayPending": "",
               "currentValue": "latest",
               "currentDigest": "sha256:fef63b8f471b4968309bbc9065a176202e30d67df56d3b8b9962a7cb8ea934d9",
               "newValue": "latest",
               "newDigest": "sha256:e6078e56685808dc36d5b31a13c80e4ecf1ebcae06476d8153d0d8be777f58ce",
               "packageFile": "Dockerfile",
               "updateType": "digest",
               "packageName": "opensuse/tumbleweed"
             }
           ]
         }
       ]

```

#### Bumps
- Bump `stream9` digest, closing #104 
- Bump `fedora41` digest, closing #106 
- Bump `Tumbleweed` digest, closing #98 