### PR TITLE
Improve e2e timeouts

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
 
@@ -48,7 +48,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: SARIF file
           path: results.sarif
@@ -57,6 +57,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@0499de31b99561a6d14a36a5f662c2a54f91beee # v4.31.2
+        uses: github/codeql-action/upload-sarif@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
         with:
           sarif_file: results.sarif

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
         echo "LIMA_VERSION=${LIMA_VERSION}" >>$GITHUB_ENV        
 
     - name: "Cache ~/.cache/lima"
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
       with:
         path: ~/.cache/lima
         key: lima-${{ env.LIMA_VERSION }}


### PR DESCRIPTION
**Context:**
- Centos8 CI failed several times in the past weeks due to timeouts - see recent failing job: https://github.com/rancher/rancher-selinux/actions/runs/20612245152/job/59198902758

**Details:**

1. e2e: increase timeouts and add verification step for cert-manager
 - Add a new kubectl wait step to confirm the readiness of cert-manager pod
 - Add --wait flag to helm rancher install step
 - Increase rancher's kubectl wait cond to 600s
 - Increase InstallRancherChart's helm timeouts from 10m to 20m

2. chore(deps): update github actions
Implements the 2 renovate PRs:
 - https://github.com/rancher/rancher-selinux/pull/111
 - https://github.com/rancher/rancher-selinux/pull/105

**Note:**
- Fedora41 job fails, this will be handled through #113 (retire Fedora41)
