### PR TITLE
policy: add rancher-ai-agent and rancher-ai-mcp support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,19 @@ For more information about enabling SELinux on Rancher or installing the rancher
 
 ## Coverage of rancher-selinux
 
-The following Rancher compnents are covered by the policy:
+The following Rancher components are covered by the policy:
 
-| Component                  | Service/Container                                                        | SELinux Type           |
-| :------------------------- | :----------------------------------------------------------------------- | :--------------------- |
-| Rancher Monitoring Chart   | [node-exporter]                                                          | `prom_node_exporter_t` |
-| Rancher Monitoring Chart   | [pushprox]                                                               | `rke_kubereader_t`     |
-| Rancher Logging Chart      | [fluentbit]                                                              | `rke_logreader_t`      |
-| RKE1                       | [flannel]                                                                | `rke_network_t`        |
-| RKE1                       | [rke] `etcd`, `rke-etcd-backup`, `kube-{apiserver,controller,scheduler}` | `rke_container_t`      |
+| Component | Service/Container | SELinux Type | CentOS 9/10 | MicroOS | Fedora 42 | E2E | Status |
+| :--- | :--- | :--- | :---: | :---: | :---: | :---: | :--- |
+| Rancher Monitoring | [node-exporter] | `prom_node_exporter_t` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | Production |
+| Rancher Monitoring | [pushprox] | `rke_kubereader_t` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | Production |
+| Rancher Logging | [fluentbit] | `rke_logreader_t` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | Production |
+| Rancher AI | [rancher-ai-agent] | `rancher_aiagent_container_t` | :white_check_mark: | :construction: | :construction: | :construction: | Testing |
+| Rancher AI | [rancher-ai-mcp] | `rancher_aimcp_container_t` | :white_check_mark: | :construction: | :construction: | :construction: | Testing |
+| RKE1 | [flannel] | `rke_network_t` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | Production |
+| RKE1 | [rke] `etcd`, `kube-apiserver`, etc. | `rke_container_t` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | Production |
+
+> **Note:** Only the specific charts and services listed above are assigned a dedicated SELinux type (within the container domain). Other Rancher components and general workloads will typically inherit the default `container_t` type provided by the base `container-selinux` policy.
 
 ## Support Matrix
 
@@ -59,3 +63,5 @@ The following list shows the expected tag to (example) transformation for RPM's
 [flannel]: https://github.com/rancher/kontainer-driver-metadata/blob/34e1e8a7a157daae54b310b199aa663c9a2ef314/rke/templates/flannel_v0.14.0.go#L239
 [pushprox]: https://github.com/rancher/charts/tree/dev-v2.11/charts/rancher-monitoring/106.0.1%2Bup66.7.1-rancher.10/charts/rkeEtcd
 [rke]: https://github.com/rancher/rke/blob/5756a3837a3c49d61f1ea2120b02149c21e4a443/hosts/hosts.go#L55
+[rancher-ai-agent]: https://github.com/rancher/rancher-ai-agent
+[rancher-ai-mcp]: https://github.com/rancher/rancher-ai-mcp

--- a/policy/centos10/rancher.te
+++ b/policy/centos10/rancher.te
@@ -104,3 +104,27 @@ corenet_tcp_bind_generic_port(prom_node_exporter_t)
 init_read_state(prom_node_exporter_t)
 selinux_read_security_files(prom_node_exporter_t)
 allow prom_node_exporter_t self:tcp_socket listen;
+
+############################################################################
+# type: rancher_aiagent_container_t                                        #
+# project: rancher/rancher-ai-agent                                        #
+# target: rancher-ai-agent container for Rancher AI                        #
+############################################################################
+
+container_domain_template(rancher_aiagent_container, container)
+corenet_tcp_bind_generic_node(rancher_aiagent_container_t)
+corenet_tcp_bind_soundd_port(rancher_aiagent_container_t)
+corenet_tcp_connect_http_port(rancher_aiagent_container_t)
+allow rancher_aiagent_container_t self:tcp_socket listen;
+
+############################################################################
+# type: rancher_aimcp_container_t				           #
+# project: rancher/rancher-ai-mcp                                          #
+# target: rancher-mcp-server container for Rancher AI                      #
+############################################################################
+
+container_domain_template(rancher_aimcp_container, container)
+corenet_tcp_bind_generic_node(rancher_aimcp_container_t)
+corenet_tcp_bind_generic_port(rancher_aimcp_container_t)
+corenet_tcp_connect_http_port(rancher_aimcp_container_t)
+allow rancher_aimcp_container_t self:tcp_socket listen;

--- a/policy/centos9/rancher.te
+++ b/policy/centos9/rancher.te
@@ -104,3 +104,27 @@ corenet_tcp_bind_generic_port(prom_node_exporter_t)
 init_read_state(prom_node_exporter_t)
 selinux_read_security_files(prom_node_exporter_t)
 allow prom_node_exporter_t self:tcp_socket listen;
+
+############################################################################
+# type: rancher_aiagent_container_t                                        #
+# project: rancher/rancher-ai-agent                                        #
+# target: rancher-ai-agent container for Rancher AI                        #
+############################################################################
+
+container_domain_template(rancher_aiagent_container, container)
+corenet_tcp_bind_generic_node(rancher_aiagent_container_t)
+corenet_tcp_bind_soundd_port(rancher_aiagent_container_t)
+corenet_tcp_connect_http_port(rancher_aiagent_container_t)
+allow rancher_aiagent_container_t self:tcp_socket listen;
+
+############################################################################
+# type: rancher_aimcp_container_t				           #
+# project: rancher/rancher-ai-mcp                                          #
+# target: rancher-mcp-server container for Rancher AI                      #
+############################################################################
+
+container_domain_template(rancher_aimcp_container, container)
+corenet_tcp_bind_generic_node(rancher_aimcp_container_t)
+corenet_tcp_bind_generic_port(rancher_aimcp_container_t)
+corenet_tcp_connect_http_port(rancher_aimcp_container_t)
+allow rancher_aimcp_container_t self:tcp_socket listen;


### PR DESCRIPTION
### Description: add rancher-ai-agent and rancher-ai-mcp support for Rancher AI

Parent: 
- https://github.com/rancher/rancher-ai-agent/pull/166

**Changes:**
- The new `rancher_aiagent_container_t` and `rancher_aimcp_container_`t type use the container domain from the `container-selinux` policy, in addition to dedicated rules such as [listen and bind port](https://github.com/andypitcher/rancher-selinux/blob/6d73d6b73abdcabe30a07b9e2b6e3f9ac1ac9e70/policy/centos10/rancher.te#L130). By default the container-selinux policy is quite broad and permissive, the main advantage by having dedicated types for each container is to avoid container/pod lateral movements and accounting.
- README.md was updated accordingly, by improving the support matrix details.

**Note:** 
1. The new policy was tested on centos9/10 only. E2E will be generated soon and other distros covered such as OpenSUSE.
2. These rules will only take effect if `selinux.enabled = true` when installing the chart, otherwise the containers will fallback to the default `container_t` provided by `container-selinux` (if installed).


**Run:**

```
[root@lima-centos10 ~]# helm install rancher-ai-agent ./chart/agent/   --namespace cattle-ai-agent-system   --create-namespace   --set seLinux.enabled=true

[root@lima-centos10 ~]# semodule -l | grep rancher
rancher
[root@lima-centos10 ~]# seinfo -t rancher_aimcp_container_t -x

Types: 1
   type rancher_aimcp_container_t, can_dump_kernel, can_receive_kernel_messages, corenet_unlabeled_type, domain, mcs_constrained_type, process_user_target, container_domain, pcmcia_typeattr_1;
[root@lima-centos10 ~]# seinfo -t rancher_aiagent_container_t -x

Types: 1
   type rancher_aiagent_container_t, can_dump_kernel, can_receive_kernel_messages, corenet_unlabeled_type, domain, mcs_constrained_type, process_user_target, container_domain, pcmcia_typeattr_1;

[root@lima-centos10 ~]# kubectl get pods -n cattle-ai-agent-system
NAME                                  READY   STATUS    RESTARTS   AGE
rancher-ai-agent-99b4bb968-r2prp      1/1     Running   0          6h14m
rancher-mcp-server-6c97b78669-j4hdg   1/1     Running   0          6h14m

[root@lima-centos10 ~]# ps -eaZ | grep rancher_
system_u:system_r:rancher_aiagent_container_t:s0:c153,c540 1398567 ? 00:00:00 pause
system_u:system_r:rancher_aimcp_container_t:s0:c476,c560 1398574 ? 00:00:00 pause
system_u:system_r:rancher_aimcp_container_t:s0:c393,c437 1398625 ? 00:00:01 mcp
system_u:system_r:rancher_aiagent_container_t:s0:c672,c1008 1398632 ? 00:01:30 python3
```


