### PR TITLE
sec: Pin microOS(tumbleweed) and Centos10(Rocky 10.2) to version/digest

### DIFF
--- a/hack/e2e/centos10.yaml
+++ b/hack/e2e/centos10.yaml
@@ -1,5 +1,7 @@
 images:
-- location: https://dl.rockylinux.org/pub/rocky/10/images/x86_64/Rocky-10-GenericCloud-Base.latest.x86_64.qcow2
-  arch: x86_64
-- location: https://dl.rockylinux.org/pub/rocky/10/images/aarch64/Rocky-10-GenericCloud-Base.latest.aarch64.qcow2
-  arch: aarch64
+- location: "https://dl.rockylinux.org/pub/rocky/10.2/images/x86_64/Rocky-10-GenericCloud-Base-10.2-20260525.0.x86_64.qcow2"
+  arch: "x86_64"
+  digest: "sha256:9fc9e9ff16888bb68ac39b0392e25c9c92684d50c85f1cce6ab549363bbc4b48"
+- location: "https://dl.rockylinux.org/pub/rocky/10.2/images/aarch64/Rocky-10-GenericCloud-Base-10.2-20260525.0.aarch64.qcow2"
+  arch: "aarch64"
+  digest: "sha256:457c8375e19496f43a25c4a6169fa11237536c53cef6f85a20ea3c5a751aa0f5"

--- a/hack/e2e/microos.yaml
+++ b/hack/e2e/microos.yaml
@@ -1,12 +1,11 @@
-minimumLimaVersion: 2.0.0
-
 images:
-# Hint: run `limactl prune` to invalidate the "Current" cache
 - location: https://download.opensuse.org/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-Cloud.qcow2
   arch: x86_64
+  digest: "sha256:d3ac5ff6d178bfd3aee8cf31deb4c13c66c01e10583d601e6dd3c9968ec04266"
 
 - location: https://download.opensuse.org/ports/aarch64/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.aarch64-Cloud.qcow2
   arch: aarch64
+  digest: "sha256:c030b6e9a319dce6720da3f7910eb2da5a10b816236396077ca44e986af1308b"
 
 provision:
 - mode: system


### PR DESCRIPTION
Fixes previous CI [fails](https://github.com/rancher/rancher-selinux/pull/167) for centos and microos, as well as improving the security posture.